### PR TITLE
BE-E1-01: add TurnResult payload to run submissions

### DIFF
--- a/backend/src/main/kotlin/com/runwar/domain/run/TurnResult.kt
+++ b/backend/src/main/kotlin/com/runwar/domain/run/TurnResult.kt
@@ -1,0 +1,35 @@
+package com.runwar.domain.run
+
+import com.runwar.domain.tile.OwnerType
+import java.time.Instant
+import java.util.UUID
+
+data class TurnResult(
+    val actionType: TerritoryActionType?,
+    val tileId: String?,
+    val h3Index: String?,
+    val previousOwner: OwnerSnapshot?,
+    val newOwner: OwnerSnapshot?,
+    val shieldBefore: Int?,
+    val shieldAfter: Int?,
+    val cooldownUntil: Instant?,
+    val disputeState: DisputeState?,
+    val capsRemaining: CapsRemaining,
+    val reasons: List<String>
+)
+
+data class OwnerSnapshot(
+    val id: UUID?,
+    val type: OwnerType?
+)
+
+data class CapsRemaining(
+    val userActionsRemaining: Int,
+    val bandeiraActionsRemaining: Int?
+)
+
+enum class DisputeState {
+    NONE,
+    STABLE,
+    DISPUTED
+}


### PR DESCRIPTION
### Motivation
- Standardize the post-run (turn) response so clients (iOS/Web) can consistently render tile updates, ownership, shields, caps and denial reasons.
- Provide useful failure/denial metadata even when a run is valid but yields no territorial effect (anti-fraud, caps, validations).

### Description
- Add a new `TurnResult` DTO and related types (`OwnerSnapshot`, `CapsRemaining`, `DisputeState`) under `backend/src/main/kotlin/com/runwar/domain/run/TurnResult.kt` to carry action, tile, owner, shield, cooldown, dispute and caps info.
- Replace the previous territory result payload in `RunService.RunSubmissionResult` with a `turnResult` constructed for every processed run in `backend/src/main/kotlin/com/runwar/domain/run/RunService.kt`, and include reasons such as validation failures, fraud flags and cap-denials.
- Ensure territorial actions are skipped when user or bandeira daily caps are reached while still saving the run and returning a `TurnResult` explaining the cap denial.
- Enrich `ShieldMechanics.ActionResult` in `backend/src/main/kotlin/com/runwar/game/ShieldMechanics.kt` with owner snapshots, cooldown metadata and a `failureWithTile` helper so `TurnResult` can consistently expose previous/new owner, shield and cooldown even on denied actions.

### Testing
- No automated tests were executed for these changes.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69718d88cf488326a2e6d1ce98834c00)