### PR TITLE
Corrige decodificação de token de autenticação no iOS

### DIFF
--- a/ios/LigaRun/Sources/LigaRun/Models/ApiModels.swift
+++ b/ios/LigaRun/Sources/LigaRun/Models/ApiModels.swift
@@ -5,11 +5,22 @@ struct AuthResponse: Codable {
     let user: User
     let token: String
     let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case user
+        case token = "accessToken"
+        case refreshToken
+    }
 }
 
 struct TokenRefreshResponse: Codable {
     let token: String
     let refreshToken: String?
+
+    enum CodingKeys: String, CodingKey {
+        case token = "accessToken"
+        case refreshToken
+    }
 }
 
 struct User: Codable, Identifiable {


### PR DESCRIPTION
### Motivation
- Corrigir falha de decode no fluxo de login/refresh ao alinhar o modelo iOS com o payload do backend que usa `accessToken`.

### Description
- Adiciona `CodingKeys` em `AuthResponse` e `TokenRefreshResponse` no arquivo `ios/LigaRun/Sources/LigaRun/Models/ApiModels.swift` para mapear `accessToken` para a propriedade `token` e garantir o correto parsing de `refreshToken`.

### Testing
- Nenhum teste automatizado foi executado durante essa alteração.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6972895d0eb08326a89de095e33879ea)