### PR TITLE
docs(ios): add environment specs for building, testing and running iOS app

### DIFF
--- a/ios/AGENTS.md
+++ b/ios/AGENTS.md
@@ -10,6 +10,19 @@
 - Build/rodar pelo Xcode (`LigaRun.xcodeproj`).
 - Mapbox via SPM; tokens em `Config/Debug.xcconfig` e `Config/Release.xcconfig`.
 
+## Ambiente para compilar, testar e rodar
+- **SO**: macOS 14+ (Sonoma ou superior).
+- **Xcode**: 15.x com Command Line Tools instalados.
+- **Ferramentas**: XcodeGen via Homebrew (`brew install xcodegen`).
+- **Simulador**: iOS 17+ (ex.: iPhone 15) instalado no Xcode.
+- **Build (CLI)**:
+  - `cd ios/LigaRun && xcodegen generate`
+  - `xcodebuild -scheme LigaRun -destination "platform=iOS Simulator,name=iPhone 15" build`
+- **Testes (CLI)**:
+  - `xcodebuild -scheme LigaRun -destination "platform=iOS Simulator,name=iPhone 15" test`
+- **Rodar**:
+  - Preferir pelo Xcode (Run no simulador/dispositivo); garantir o simulador iOS 17+ ativo.
+
 ## Padrões
 - Manter SwiftUI/Combine simples; evitar mudar bundle id ou targets sem pedido.
 - Atualize `configFiles` em `project.yml` se adicionar novas configs.


### PR DESCRIPTION
### Motivation
- Clarify required local environment and CLI commands so contributors can reliably compile, test and run the iOS app.

### Description
- Added an "Ambiente para compilar, testar e rodar" section to `ios/AGENTS.md` documenting required `macOS 14+`, `Xcode 15.x`, `xcodegen` installation and CLI commands `xcodegen generate`, `xcodebuild -scheme LigaRun -destination "platform=iOS Simulator,name=iPhone 15" build` and `xcodebuild -scheme LigaRun -destination "platform=iOS Simulator,name=iPhone 15" test`.

### Testing
- No automated tests were run because this is a documentation change that requires a macOS environment with Xcode to execute the listed CLI commands.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6978f94e0a2c8326bf84322c5bc94517)