### PR TITLE
Fix telemetry tests and handle ResponseStatusException

### DIFF
--- a/backend/src/main/kotlin/com/runwar/config/GlobalExceptionHandler.kt
+++ b/backend/src/main/kotlin/com/runwar/config/GlobalExceptionHandler.kt
@@ -9,6 +9,7 @@ import org.springframework.validation.FieldError
 import org.springframework.web.bind.MethodArgumentNotValidException
 import org.springframework.web.bind.annotation.ExceptionHandler
 import org.springframework.web.bind.annotation.RestControllerAdvice
+import org.springframework.web.server.ResponseStatusException
 
 @RestControllerAdvice
 class GlobalExceptionHandler {
@@ -73,6 +74,14 @@ class GlobalExceptionHandler {
         return ResponseEntity.status(HttpStatus.FORBIDDEN).body(
             ApiErrorResponse("FORBIDDEN", "Access denied")
         )
+    }
+
+    @ExceptionHandler(ResponseStatusException::class)
+    fun handleResponseStatus(e: ResponseStatusException): ResponseEntity<ApiErrorResponse> {
+        val status = e.statusCode
+        val error = (status as? HttpStatus)?.name ?: status.toString()
+        val message = e.reason ?: "Request failed"
+        return ResponseEntity.status(status).body(ApiErrorResponse(error, message))
     }
     
     @ExceptionHandler(Exception::class)

--- a/backend/src/test/kotlin/com/runwar/telemetry/RunTelemetryServiceTest.kt
+++ b/backend/src/test/kotlin/com/runwar/telemetry/RunTelemetryServiceTest.kt
@@ -24,7 +24,7 @@ import java.time.Instant
 import java.util.UUID
 
 class RunTelemetryServiceTest {
-    private val objectMapper = jacksonObjectMapper()
+    private val objectMapper = jacksonObjectMapper().findAndRegisterModules()
 
     @Test
     fun `recordRunTelemetry persists structured event`() {


### PR DESCRIPTION
## Summary
- stabilize telemetry controller tests by avoiding springSecurity filter chain and wiring principal resolution in MockMvc
- register Jackson JavaTime modules in telemetry service tests
- return structured error bodies for ResponseStatusException

## Testing
- JAVA_HOME=/Library/Java/JavaVirtualMachines/temurin-21.jdk/Contents/Home ./gradlew test --tests com.runwar.telemetry.RunTelemetryControllerTest --tests com.runwar.telemetry.RunTelemetryServiceTest