### PR TITLE
Add Gemini Nano Banana image generation skill

### DIFF
--- a/.agents/skills/imagegen-gemini-nano-banana/SKILL.md
+++ b/.agents/skills/imagegen-gemini-nano-banana/SKILL.md
@@ -1,0 +1,24 @@
+---
+name: imagegen-gemini-nano-banana
+description: Use when the user asks to generate a new image (banner, post, mockup, illustration) or to turn a textual brief into a production-ready image prompt and render it via Gemini Nano Banana (Google Gemini image generation). Do not use for video. Do not use for simple text-only brainstorming.
+---
+
+## Goal
+Generate a single high-quality image using Google Gemini image generation and save it into `./assets/generated/`.
+
+## Inputs to collect (ask only if missing)
+- Purpose: (e.g., Instagram feed 1:1, story 9:16, banner 16:9, icon 1:1)
+- Style: (photorealistic, flat illustration, 3D, minimal, etc.)
+- Text on image? If yes: exact text and language (warn about small text legibility)
+- Brand constraints (colors, logos, layout rules)
+- Output filename (default: `image.png`)
+
+## Output
+- Generate the image file in `./assets/generated/<filename>.png`
+- Print the saved path and a short summary of the prompt used.
+
+## Execution steps
+1. Draft a final image prompt (concise, unambiguous).
+2. Run `python3 .agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py --prompt "<PROMPT>" --out "./assets/generated/<filename>.png"`.
+3. If the command fails due to missing API key, instruct the user to set `GOOGLE_API_KEY` and re-run.
+4. If the user requests multiple variants, run multiple times with different `--seed` values and distinct filenames.

--- a/.agents/skills/imagegen-gemini-nano-banana/agents/google.yaml
+++ b/.agents/skills/imagegen-gemini-nano-banana/agents/google.yaml
@@ -1,0 +1,9 @@
+interface:
+  display_name: "ImageGen (Gemini Nano Banana)"
+  short_description: "Gera imagens (posts, banners, mockups) via Gemini Nano Banana e salva em assets/generated."
+  icon_small: "./assets/icon.svg"
+  icon_large: "./assets/icon.png"
+  brand_color: "#4285F4"
+  default_prompt: "Gere uma imagem a partir deste briefing: "
+dependencies:
+  tools: []

--- a/.agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py
+++ b/.agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py
@@ -1,0 +1,107 @@
+#!/usr/bin/env python3
+import argparse
+import base64
+import os
+import sys
+from pathlib import Path
+
+
+def _extract_image_bytes(response):
+    """Best-effort extraction for google-genai SDK response shapes."""
+    # Newer SDKs may expose quick access on response.generated_images
+    generated_images = getattr(response, "generated_images", None)
+    if generated_images:
+        first = generated_images[0]
+        image = getattr(first, "image", None)
+        image_bytes = getattr(image, "image_bytes", None)
+        if image_bytes:
+            return image_bytes
+
+    candidates = getattr(response, "candidates", None) or []
+    for candidate in candidates:
+        content = getattr(candidate, "content", None)
+        parts = getattr(content, "parts", None) or []
+        for part in parts:
+            inline_data = getattr(part, "inline_data", None)
+            if not inline_data:
+                continue
+            data = getattr(inline_data, "data", None)
+            if isinstance(data, bytes):
+                return data
+            if isinstance(data, str):
+                try:
+                    return base64.b64decode(data)
+                except Exception:
+                    continue
+    return None
+
+
+def main():
+    parser = argparse.ArgumentParser(description="Generate an image using Gemini Nano Banana.")
+    parser.add_argument("--prompt", required=True, help="Text prompt for the image.")
+    parser.add_argument("--out", required=True, help="Output PNG path.")
+    parser.add_argument(
+        "--model",
+        default="gemini-2.5-flash-image-preview",
+        help="Gemini image model name.",
+    )
+    parser.add_argument("--seed", type=int, default=None, help="Optional seed for determinism (if supported).")
+    args = parser.parse_args()
+
+    api_key = os.getenv("GOOGLE_API_KEY")
+    if not api_key:
+        print("ERROR: GOOGLE_API_KEY is not set.", file=sys.stderr)
+        print("Set it like: export GOOGLE_API_KEY='...'", file=sys.stderr)
+        sys.exit(2)
+
+    try:
+        from google import genai
+        from google.genai import types
+    except ImportError:
+        print("ERROR: Missing dependency: google-genai", file=sys.stderr)
+        print("Install with: pip install google-genai", file=sys.stderr)
+        sys.exit(3)
+
+    out_path = Path(args.out)
+    out_path.parent.mkdir(parents=True, exist_ok=True)
+
+    client = genai.Client(api_key=api_key)
+
+    try:
+        config = types.GenerateContentConfig(response_modalities=["IMAGE", "TEXT"])
+        if args.seed is not None:
+            setattr(config, "seed", args.seed)
+
+        try:
+            response = client.models.generate_content(
+                model=args.model,
+                contents=args.prompt,
+                config=config,
+            )
+        except Exception as exc:
+            if args.seed is not None and "seed" in str(exc).lower():
+                config = types.GenerateContentConfig(response_modalities=["IMAGE", "TEXT"])
+                response = client.models.generate_content(
+                    model=args.model,
+                    contents=args.prompt,
+                    config=config,
+                )
+            else:
+                raise
+
+        image_bytes = _extract_image_bytes(response)
+        if not image_bytes:
+            raise RuntimeError("Model response did not include image bytes.")
+
+        out_path.write_bytes(image_bytes)
+        print(f"Saved: {out_path}")
+        print("Prompt used:")
+        print(args.prompt)
+    except Exception as e:
+        print("ERROR while generating image:", file=sys.stderr)
+        print(str(e), file=sys.stderr)
+        sys.exit(1)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
### Motivation
- Provide a reusable image-generation skill that mirrors the existing `imagegen` workflow but targets Google Gemini (Gemini Nano Banana) so agents can produce images via Google GenAI.
- Keep the same UX contract (generate files into `./assets/generated/`) and predictable CLI for automatable and interactive usage.

### Description
- Add `.agents/skills/imagegen-gemini-nano-banana/SKILL.md` containing skill metadata, input checklist, output contract, and execution steps.
- Add `scripts/generate_image.py` implementing Gemini image generation with a default model `gemini-2.5-flash-image-preview`, optional `--seed`, robust best-effort extraction of image bytes from multiple `google-genai` response shapes, and clear error handling for missing `GOOGLE_API_KEY` and missing `google-genai` dependency.
- Add agent UI metadata at `.agents/skills/imagegen-gemini-nano-banana/agents/google.yaml` for display name, description, icons, and default prompt.
- Work performed on a dedicated branch `feat/skill-gemini-nano-banana` and committed as the feature addition.

### Testing
- Ran `python3 -m py_compile .agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py` and it completed successfully.
- Ran `python3 .agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py --help` and it printed the CLI help successfully.
- Ran `unset GOOGLE_API_KEY && python3 .agents/skills/imagegen-gemini-nano-banana/scripts/generate_image.py --prompt 'test' --out /tmp/test.png` and validated the expected failure path with exit code `2` and the correct missing-API-key message.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69854da48dd483268ce80ffbb460a5fb)