### PR TITLE
Enable Gradle configuration cache and update README

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -35,6 +35,8 @@ export RUNWAR_SEED_ENABLED=true # opcional: insere dados mock para testes
 
 ### 3. Build e Run
 
+O Gradle está configurado com configuration cache habilitado por padrão para acelerar execuções repetidas.
+
 ```bash
 # Build
 ./gradlew build

--- a/backend/gradle.properties
+++ b/backend/gradle.properties
@@ -1,0 +1,1 @@
+org.gradle.configuration-cache=true

--- a/ios/LigaRun/Sources/LigaRun/Features/Map/MapViewModel.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Map/MapViewModel.swift
@@ -89,10 +89,6 @@ final class MapViewModel: ObservableObject {
             }
         }
 
-<<<<<<< HEAD
-=======
-
->>>>>>> origin/master
         return "Não foi possível carregar o mapa agora. Tente novamente."
     }
 


### PR DESCRIPTION
Enable the Gradle configuration cache by default to speed up repeated executions and update the README to reflect this change.