### PR TITLE
iOS: support quadra field aliases in API decoding

### DIFF
--- a/ios/LigaRun/LigaRun.xcodeproj/project.pbxproj
+++ b/ios/LigaRun/LigaRun.xcodeproj/project.pbxproj
@@ -54,6 +54,7 @@
 		ED0C637E0C9439D0354ECD76 /* GeoUtilsTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 161FC3E3EB5EE89C8D12E9F0 /* GeoUtilsTests.swift */; };
 		EE4F5DC811D634C13E339735 /* LocationManager.swift in Sources */ = {isa = PBXBuildFile; fileRef = B3E368A6F9923688C82AA9CD /* LocationManager.swift */; };
 		EF6C5942D98A6DED50ADAB26 /* AppEnvironment.swift in Sources */ = {isa = PBXBuildFile; fileRef = A561AC531A941CF1DC17B391 /* AppEnvironment.swift */; };
+		F85F4F195506DED983AB5E5A /* ApiModelsDecodingTests.swift in Sources */ = {isa = PBXBuildFile; fileRef = 593AC30F97D1F9B14155A887 /* ApiModelsDecodingTests.swift */; };
 		FBD50FC0BE2B5D6EA55F29E5 /* BandeirasViewModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = 687A5818C9839BD446B9CCBA /* BandeirasViewModel.swift */; };
 /* End PBXBuildFile section */
 
@@ -86,6 +87,7 @@
 		4FCA68DFEAEAEFFEEA94FAC3 /* CompanionRunManagerTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRunManagerTests.swift; sourceTree = "<group>"; };
 		5120777A2B8A3D3C793D3036 /* CompanionRunManager.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = CompanionRunManager.swift; sourceTree = "<group>"; };
 		5211D010B78B5D8BBF901EF3 /* QuadraEligibilityPolicyTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = QuadraEligibilityPolicyTests.swift; sourceTree = "<group>"; };
+		593AC30F97D1F9B14155A887 /* ApiModelsDecodingTests.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ApiModelsDecodingTests.swift; sourceTree = "<group>"; };
 		5F5D2B441C2DC5B52A3BAC8D /* RunSessionStore.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = RunSessionStore.swift; sourceTree = "<group>"; };
 		687A5818C9839BD446B9CCBA /* BandeirasViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = BandeirasViewModel.swift; sourceTree = "<group>"; };
 		68A46DA068E959FFAEE24347 /* AuthViewModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AuthViewModel.swift; sourceTree = "<group>"; };
@@ -288,6 +290,7 @@
 		FAA8B621927C5CBD2D1916A7 /* LigaRunTests */ = {
 			isa = PBXGroup;
 			children = (
+				593AC30F97D1F9B14155A887 /* ApiModelsDecodingTests.swift */,
 				D56C2F8711166F1582C2B3CA /* BandeirasViewModelTests.swift */,
 				4FCA68DFEAEAEFFEEA94FAC3 /* CompanionRunManagerTests.swift */,
 				EBC788670B9D532DE9FCAADA /* CompanionSyncStateTests.swift */,
@@ -418,6 +421,7 @@
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
+				F85F4F195506DED983AB5E5A /* ApiModelsDecodingTests.swift in Sources */,
 				532970604BDC326CC3C445D7 /* BandeirasViewModelTests.swift in Sources */,
 				8D2DDA3FCD5B49B710C59212 /* CompanionRunManagerTests.swift in Sources */,
 				CC0630A644CF12E8A8FC05D6 /* CompanionSyncStateTests.swift in Sources */,

--- a/ios/LigaRun/Sources/LigaRun/Models/ApiModels.swift
+++ b/ios/LigaRun/Sources/LigaRun/Models/ApiModels.swift
@@ -1,7 +1,7 @@
 import Foundation
 import CoreLocation
 
-struct AuthResponse: Codable {
+struct AuthResponse: Decodable {
     let user: User
     let token: String
     let refreshToken: String?
@@ -13,7 +13,7 @@ struct AuthResponse: Codable {
     }
 }
 
-struct TokenRefreshResponse: Codable {
+struct TokenRefreshResponse: Decodable {
     let token: String
     let refreshToken: String?
 
@@ -23,7 +23,7 @@ struct TokenRefreshResponse: Codable {
     }
 }
 
-struct User: Codable, Identifiable {
+struct User: Decodable, Identifiable {
     let id: String
     let email: String
     var username: String
@@ -35,6 +35,53 @@ struct User: Codable, Identifiable {
     var totalRuns: Int
     var totalDistance: Double
     var totalTilesConquered: Int
+
+    init(
+        id: String,
+        email: String,
+        username: String,
+        avatarUrl: String?,
+        isPublic: Bool,
+        bandeiraId: String?,
+        bandeiraName: String?,
+        role: String,
+        totalRuns: Int,
+        totalDistance: Double,
+        totalTilesConquered: Int
+    ) {
+        self.id = id
+        self.email = email
+        self.username = username
+        self.avatarUrl = avatarUrl
+        self.isPublic = isPublic
+        self.bandeiraId = bandeiraId
+        self.bandeiraName = bandeiraName
+        self.role = role
+        self.totalRuns = totalRuns
+        self.totalDistance = totalDistance
+        self.totalTilesConquered = totalTilesConquered
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, email, username, avatarUrl, isPublic, bandeiraId, bandeiraName, role, totalRuns, totalDistance
+        case totalTilesConquered, totalQuadrasConquered
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        email = try container.decode(String.self, forKey: .email)
+        username = try container.decode(String.self, forKey: .username)
+        avatarUrl = try container.decodeIfPresent(String.self, forKey: .avatarUrl)
+        isPublic = try container.decode(Bool.self, forKey: .isPublic)
+        bandeiraId = try container.decodeIfPresent(String.self, forKey: .bandeiraId)
+        bandeiraName = try container.decodeIfPresent(String.self, forKey: .bandeiraName)
+        role = try container.decode(String.self, forKey: .role)
+        totalRuns = try container.decode(Int.self, forKey: .totalRuns)
+        totalDistance = try container.decode(Double.self, forKey: .totalDistance)
+        totalTilesConquered = try container.decodeIfPresent(Int.self, forKey: .totalTilesConquered)
+            ?? container.decode(Int.self, forKey: .totalQuadrasConquered)
+    }
 }
 
 struct UpdateProfileRequest: Codable {
@@ -73,12 +120,48 @@ struct Quadra: Codable, Identifiable {
 
 typealias Tile = Quadra
 
-struct QuadraStats: Codable {
+struct QuadraStats: Decodable {
     let totalTiles: Int
     let ownedTiles: Int
     let neutralTiles: Int
     let tilesInDispute: Int
     let disputePercentage: Double
+
+    init(
+        totalTiles: Int,
+        ownedTiles: Int,
+        neutralTiles: Int,
+        tilesInDispute: Int,
+        disputePercentage: Double
+    ) {
+        self.totalTiles = totalTiles
+        self.ownedTiles = ownedTiles
+        self.neutralTiles = neutralTiles
+        self.tilesInDispute = tilesInDispute
+        self.disputePercentage = disputePercentage
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case totalTiles, ownedTiles, neutralTiles, tilesInDispute, disputePercentage
+        case totalQuadras, ownedQuadras, neutralQuadras, quadrasInDispute
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        totalTiles = try container.decodeIfPresent(Int.self, forKey: .totalTiles)
+            ?? container.decode(Int.self, forKey: .totalQuadras)
+        ownedTiles = try container.decodeIfPresent(Int.self, forKey: .ownedTiles)
+            ?? container.decode(Int.self, forKey: .ownedQuadras)
+        neutralTiles = try container.decodeIfPresent(Int.self, forKey: .neutralTiles)
+            ?? container.decode(Int.self, forKey: .neutralQuadras)
+        tilesInDispute = try container.decodeIfPresent(Int.self, forKey: .tilesInDispute)
+            ?? container.decode(Int.self, forKey: .quadrasInDispute)
+        if let intDispute = try container.decodeIfPresent(Int.self, forKey: .disputePercentage) {
+            disputePercentage = Double(intDispute)
+        } else {
+            disputePercentage = try container.decode(Double.self, forKey: .disputePercentage)
+        }
+    }
 }
 
 struct Run: Decodable, Identifiable {
@@ -246,7 +329,7 @@ struct DailyStatus: Codable {
     let bandeiraActionCap: Int?
 }
 
-struct Bandeira: Codable, Identifiable {
+struct Bandeira: Decodable, Identifiable {
     let id: String
     let name: String
     let slug: String
@@ -258,14 +341,89 @@ struct Bandeira: Codable, Identifiable {
     let totalTiles: Int
     let createdById: String
     let createdByUsername: String
+
+    init(
+        id: String,
+        name: String,
+        slug: String,
+        category: String,
+        color: String,
+        logoUrl: String?,
+        description: String?,
+        memberCount: Int,
+        totalTiles: Int,
+        createdById: String,
+        createdByUsername: String
+    ) {
+        self.id = id
+        self.name = name
+        self.slug = slug
+        self.category = category
+        self.color = color
+        self.logoUrl = logoUrl
+        self.description = description
+        self.memberCount = memberCount
+        self.totalTiles = totalTiles
+        self.createdById = createdById
+        self.createdByUsername = createdByUsername
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, name, slug, category, color, logoUrl, description, memberCount, totalTiles, createdById, createdByUsername
+        case totalQuadras
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        name = try container.decode(String.self, forKey: .name)
+        slug = try container.decode(String.self, forKey: .slug)
+        category = try container.decode(String.self, forKey: .category)
+        color = try container.decode(String.self, forKey: .color)
+        logoUrl = try container.decodeIfPresent(String.self, forKey: .logoUrl)
+        description = try container.decodeIfPresent(String.self, forKey: .description)
+        memberCount = try container.decode(Int.self, forKey: .memberCount)
+        totalTiles = try container.decodeIfPresent(Int.self, forKey: .totalTiles)
+            ?? container.decode(Int.self, forKey: .totalQuadras)
+        createdById = try container.decode(String.self, forKey: .createdById)
+        createdByUsername = try container.decode(String.self, forKey: .createdByUsername)
+    }
 }
 
-struct BandeiraMember: Codable, Identifiable {
+struct BandeiraMember: Decodable, Identifiable {
     let id: String
     let username: String
     let avatarUrl: String?
     let role: String
     let totalTilesConquered: Int
+
+    init(
+        id: String,
+        username: String,
+        avatarUrl: String?,
+        role: String,
+        totalTilesConquered: Int
+    ) {
+        self.id = id
+        self.username = username
+        self.avatarUrl = avatarUrl
+        self.role = role
+        self.totalTilesConquered = totalTilesConquered
+    }
+
+    enum CodingKeys: String, CodingKey {
+        case id, username, avatarUrl, role, totalTilesConquered, totalQuadrasConquered
+    }
+
+    init(from decoder: Decoder) throws {
+        let container = try decoder.container(keyedBy: CodingKeys.self)
+        id = try container.decode(String.self, forKey: .id)
+        username = try container.decode(String.self, forKey: .username)
+        avatarUrl = try container.decodeIfPresent(String.self, forKey: .avatarUrl)
+        role = try container.decode(String.self, forKey: .role)
+        totalTilesConquered = try container.decodeIfPresent(Int.self, forKey: .totalTilesConquered)
+            ?? container.decode(Int.self, forKey: .totalQuadrasConquered)
+    }
 }
 
 struct CreateBandeiraRequest: Codable {

--- a/ios/LigaRun/Tests/LigaRunTests/ApiModelsDecodingTests.swift
+++ b/ios/LigaRun/Tests/LigaRunTests/ApiModelsDecodingTests.swift
@@ -1,0 +1,94 @@
+import Foundation
+import XCTest
+@testable import LigaRun
+
+final class ApiModelsDecodingTests: XCTestCase {
+    func testAuthResponseDecodesUserWithQuadraFieldNames() throws {
+        let json = """
+        {
+          "accessToken": "token-123",
+          "refreshToken": "refresh-123",
+          "user": {
+            "id": "u1",
+            "email": "runner@ligarun.app",
+            "username": "runner",
+            "avatarUrl": null,
+            "isPublic": true,
+            "bandeiraId": null,
+            "bandeiraName": null,
+            "role": "USER",
+            "totalRuns": 7,
+            "totalDistance": 15.2,
+            "totalDistanceMeters": 15200,
+            "totalQuadrasConquered": 4
+          }
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(AuthResponse.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.token, "token-123")
+        XCTAssertEqual(decoded.refreshToken, "refresh-123")
+        XCTAssertEqual(decoded.user.totalTilesConquered, 4)
+    }
+
+    func testQuadraStatsDecodesQuadraFieldNames() throws {
+        let json = """
+        {
+          "totalQuadras": 100,
+          "ownedQuadras": 25,
+          "neutralQuadras": 75,
+          "quadrasInDispute": 5,
+          "disputePercentage": 20
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(QuadraStats.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.totalTiles, 100)
+        XCTAssertEqual(decoded.ownedTiles, 25)
+        XCTAssertEqual(decoded.neutralTiles, 75)
+        XCTAssertEqual(decoded.tilesInDispute, 5)
+        XCTAssertEqual(decoded.disputePercentage, 20)
+    }
+
+    func testBandeiraDecodesQuadraFieldName() throws {
+        let json = """
+        {
+          "id": "b1",
+          "name": "Liga Azul",
+          "slug": "liga-azul",
+          "category": "running",
+          "color": "#0088FF",
+          "logoUrl": null,
+          "description": "Equipe",
+          "memberCount": 10,
+          "totalQuadras": 25,
+          "createdById": "u1",
+          "createdByUsername": "captain"
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(Bandeira.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.totalTiles, 25)
+        XCTAssertEqual(decoded.name, "Liga Azul")
+    }
+
+    func testBandeiraMemberDecodesQuadraFieldName() throws {
+        let json = """
+        {
+          "id": "u2",
+          "username": "sprinter",
+          "avatarUrl": null,
+          "role": "MEMBER",
+          "totalQuadrasConquered": 11
+        }
+        """
+
+        let decoded = try JSONDecoder().decode(BandeiraMember.self, from: Data(json.utf8))
+
+        XCTAssertEqual(decoded.totalTilesConquered, 11)
+        XCTAssertEqual(decoded.username, "sprinter")
+    }
+}


### PR DESCRIPTION
## Summary
- make core API response models decode legacy and quadra-based field names
- add explicit decoding fallbacks for totalQuadras* to totalTiles* mappings
- add ApiModelsDecodingTests coverage for auth, stats, bandeira, and member payloads
- register new test file in LigaRun.xcodeproj

## Validation
- xcodebuild -project ios/LigaRun/LigaRun.xcodeproj -scheme LigaRun -destination "platform=iOS Simulator,name=iPhone 17" test
- Result: TEST SUCCEEDED (90 tests, 0 failures)
