### PR TITLE
feat(ios): add territorial map filters

### DIFF
--- a/ios/LigaRun/Sources/LigaRun/Features/Map/MapScreen.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Map/MapScreen.swift
@@ -5,6 +5,7 @@ struct MapScreen: View {
     @ObservedObject private var session: SessionStore
     @StateObject private var viewModel: MapViewModel
     @State private var showingActiveRun = false
+    @State private var pendingFocusContext: MapFocusContext?
 
     init(session: SessionStore) {
         self.session = session
@@ -18,7 +19,13 @@ struct MapScreen: View {
                 quadras: viewModel.quadras,
                 focusCoordinate: viewModel.focusCoordinate,
                 onVisibleRegionChanged: { bounds in
-                    Task { await viewModel.loadQuadras(bounds: bounds.toTuple) }
+                    Task {
+                        await viewModel.updateVisibleBounds(
+                            bounds.toTuple,
+                            filter: session.activeMapOwnershipFilter,
+                            focusContext: session.mapFocusContext
+                        )
+                    }
                 },
                 onQuadraTapped: { quadra in
                     viewModel.selectedQuadra = quadra
@@ -27,29 +34,39 @@ struct MapScreen: View {
             .ignoresSafeArea()
 
             VStack(spacing: 16) {
-                HStack(alignment: .top) {
-                    quadraStateLegend
-                    Spacer()
-                    VStack(alignment: .trailing, spacing: 8) {
+                VStack(alignment: .leading, spacing: 12) {
+                    mapFilterBar
+
+                    HStack(alignment: .top) {
+                        quadraStateLegend
+                        Spacer()
                         if viewModel.isLoading {
                             ProgressView("Carregando quadras...")
                                 .padding(8)
                                 .background(.ultraThinMaterial, in: Capsule())
                         }
-
-                        Button {
-                            Task { await viewModel.refreshDisputedQuadras() }
-                        } label: {
-                            Label("Ver disputas", systemImage: "flame")
-                                .font(.subheadline.weight(.semibold))
-                                .padding(.horizontal, 12)
-                                .padding(.vertical, 8)
-                                .background(.thinMaterial, in: Capsule())
-                        }
                     }
                 }
                 .padding(.horizontal)
                 .padding(.top)
+
+                if let contextualMessage = viewModel.contextualMessage {
+                    inlineMessageCard(
+                        title: "Contexto do mapa",
+                        message: contextualMessage,
+                        systemImage: "scope"
+                    )
+                    .padding(.horizontal)
+                }
+
+                if let emptyState = viewModel.emptyState {
+                    inlineMessageCard(
+                        title: emptyState.title,
+                        message: emptyState.message,
+                        systemImage: "map"
+                    )
+                    .padding(.horizontal)
+                }
 
                 Spacer()
 
@@ -91,22 +108,33 @@ struct MapScreen: View {
         } message: {
             Text(viewModel.errorMessage ?? "")
         }
+        .task {
+            await applySharedMapState()
+        }
+        .onChange(of: session.activeMapOwnershipFilter) { _ in
+            Task {
+                await viewModel.selectFilter(
+                    session.activeMapOwnershipFilter,
+                    focusContext: consumePendingFocusContext()
+                )
+            }
+        }
         .onChange(of: session.mapFocusQuadraId) { newValue in
             guard let quadraId = newValue else { return }
             Task {
-                await viewModel.refreshVisibleQuadras()
+                await applySharedMapState()
                 await viewModel.focusOnQuadra(id: quadraId)
                 session.mapFocusQuadraId = nil
             }
         }
-        .onChange(of: session.mapFocusContext) { _ in
-            guard session.selectedTab == .map else { return }
+        .onChange(of: session.mapFocusContext) { newValue in
+            guard newValue != nil, session.selectedTabIndex == 0 else { return }
             Task {
                 await applySharedMapState()
             }
         }
-        .onChange(of: session.selectedTabIndex) { _ in
-            guard session.selectedTab == .map else { return }
+        .onChange(of: session.selectedTabIndex) { newValue in
+            guard newValue == 0 else { return }
             Task {
                 await applySharedMapState()
             }
@@ -118,17 +146,26 @@ struct MapScreen: View {
 
     @MainActor
     private func applySharedMapState() async {
-        if let focusContext = session.consumeMapFocusContext(),
-           session.activeMapOwnershipFilter == .all {
+        let focusContext = session.mapFocusContext
+        pendingFocusContext = focusContext
+        session.mapFocusContext = nil
+
+        if let focusContext, session.activeMapOwnershipFilter == .all {
             session.activeMapOwnershipFilter = defaultFilter(for: focusContext)
+            return
         }
 
-        switch session.activeMapOwnershipFilter {
-        case .disputed:
-            await viewModel.refreshDisputedQuadras()
-        case .all, .mine, .myBandeira:
-            await viewModel.refreshVisibleQuadras()
-        }
+        await viewModel.selectFilter(
+            session.activeMapOwnershipFilter,
+            focusContext: consumePendingFocusContext()
+        )
+    }
+
+    @MainActor
+    private func consumePendingFocusContext() -> MapFocusContext? {
+        let focusContext = pendingFocusContext
+        pendingFocusContext = nil
+        return focusContext
     }
 
     private func defaultFilter(for focusContext: MapFocusContext) -> MapOwnershipFilter {
@@ -154,6 +191,82 @@ struct MapScreen: View {
         .padding(.horizontal, 12)
         .padding(.vertical, 10)
         .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 12, style: .continuous))
+    }
+
+    private var mapFilterBar: some View {
+        ScrollView(.horizontal, showsIndicators: false) {
+            HStack(spacing: 10) {
+                ForEach(MapOwnershipFilter.allCases, id: \.self) { filter in
+                    let isSelected = session.activeMapOwnershipFilter == filter
+                    Button {
+                        session.activeMapOwnershipFilter = filter
+                    } label: {
+                        Label(filterTitle(for: filter), systemImage: filterIcon(for: filter))
+                            .font(.subheadline.weight(.semibold))
+                            .padding(.horizontal, 14)
+                            .padding(.vertical, 10)
+                            .foregroundColor(isSelected ? .white : .primary)
+                            .background(
+                                RoundedRectangle(cornerRadius: 14, style: .continuous)
+                                    .fill(isSelected ? Color.accentColor : Color.white.opacity(0.18))
+                            )
+                    }
+                    .buttonStyle(.plain)
+                }
+            }
+            .padding(6)
+            .background(.ultraThinMaterial, in: RoundedRectangle(cornerRadius: 18, style: .continuous))
+        }
+    }
+
+    private func inlineMessageCard(
+        title: String,
+        message: String,
+        systemImage: String
+    ) -> some View {
+        HStack(alignment: .top, spacing: 12) {
+            Image(systemName: systemImage)
+                .foregroundColor(.accentColor)
+                .padding(.top, 2)
+
+            VStack(alignment: .leading, spacing: 4) {
+                Text(title)
+                    .font(.headline)
+                Text(message)
+                    .font(.subheadline)
+                    .foregroundColor(.secondary)
+            }
+
+            Spacer(minLength: 0)
+        }
+        .padding(14)
+        .background(.thinMaterial, in: RoundedRectangle(cornerRadius: 16, style: .continuous))
+    }
+
+    private func filterTitle(for filter: MapOwnershipFilter) -> String {
+        switch filter {
+        case .all:
+            return "Todas"
+        case .disputed:
+            return "Em disputa"
+        case .mine:
+            return "Minhas"
+        case .myBandeira:
+            return "Da minha bandeira"
+        }
+    }
+
+    private func filterIcon(for filter: MapOwnershipFilter) -> String {
+        switch filter {
+        case .all:
+            return "square.grid.2x2"
+        case .disputed:
+            return "flame.fill"
+        case .mine:
+            return "figure.run"
+        case .myBandeira:
+            return "flag.fill"
+        }
     }
 }
 
@@ -204,23 +317,138 @@ struct QuadraDetailView: View {
                     .tint(shieldColor(for: quadra.shield))
             }
 
-            if quadra.isInDispute {
-                Label("Quadra em disputa", systemImage: "flame.fill")
-                    .foregroundColor(.orange)
-            }
+            territoryDecisionCard
 
-            if quadra.isInCooldown {
-                Label("Em cooldown", systemImage: "lock.fill")
-                    .foregroundColor(.blue)
-            }
+            VStack(alignment: .leading, spacing: 10) {
+                detailRow(
+                    title: "Estado territorial",
+                    value: territorialStateLabel,
+                    systemImage: territorialStateIcon,
+                    tint: territorialStateColor
+                )
 
-            if let guardian = quadra.guardianName {
-                Label("Guardião: \(guardian)", systemImage: "shield.lefthalf.fill")
+                if let champion = quadra.championName {
+                    detailRow(
+                        title: "Campeao",
+                        value: champion,
+                        systemImage: "crown.fill",
+                        tint: .yellow
+                    )
+                }
+
+                if let guardian = quadra.guardianName {
+                    detailRow(
+                        title: "Guardiao",
+                        value: guardian,
+                        systemImage: "shield.lefthalf.fill",
+                        tint: .blue
+                    )
+                }
             }
 
             Spacer()
         }
         .padding()
+    }
+
+    private var territoryDecisionCard: some View {
+        VStack(alignment: .leading, spacing: 6) {
+            Text(decisionSummaryTitle)
+                .font(.headline)
+            Text(decisionSummaryMessage)
+                .font(.subheadline)
+                .foregroundColor(.secondary)
+        }
+        .padding(12)
+        .frame(maxWidth: .infinity, alignment: .leading)
+        .background(Color.white.opacity(0.08), in: RoundedRectangle(cornerRadius: 14, style: .continuous))
+    }
+
+    private func detailRow(
+        title: String,
+        value: String,
+        systemImage: String,
+        tint: Color
+    ) -> some View {
+        HStack {
+            Label(title, systemImage: systemImage)
+                .foregroundColor(tint)
+            Spacer()
+            Text(value)
+                .multilineTextAlignment(.trailing)
+        }
+        .font(.subheadline)
+    }
+
+    private var territorialStateLabel: String {
+        if quadra.isInDispute {
+            return "Em disputa"
+        }
+        if quadra.isInCooldown {
+            return "Em cooldown"
+        }
+        if quadra.ownerType == nil {
+            return "Neutra"
+        }
+        return "Dominada"
+    }
+
+    private var territorialStateIcon: String {
+        if quadra.isInDispute {
+            return "flame.fill"
+        }
+        if quadra.isInCooldown {
+            return "lock.fill"
+        }
+        if quadra.ownerType == nil {
+            return "circle.dotted"
+        }
+        return "shield.fill"
+    }
+
+    private var territorialStateColor: Color {
+        if quadra.isInDispute {
+            return .orange
+        }
+        if quadra.isInCooldown {
+            return .blue
+        }
+        if quadra.ownerType == nil {
+            return .gray
+        }
+        return .green
+    }
+
+    private var decisionSummaryTitle: String {
+        if quadra.isInDispute {
+            return "Disputa aberta"
+        }
+        if quadra.ownerType == nil {
+            return "Janela de conquista"
+        }
+        if quadra.isInCooldown {
+            return "Territorio protegido"
+        }
+        if quadra.shield < 40 {
+            return "Defesa fragil"
+        }
+        return "Territorio estavel"
+    }
+
+    private var decisionSummaryMessage: String {
+        if quadra.isInDispute {
+            return "A quadra esta em disputa agora. Vale agir rapido para defender ou virar o controle."
+        }
+        if quadra.ownerType == nil {
+            return "Sem dono atual. Boa oportunidade para conquistar territorio sem perder contexto da camera."
+        }
+        if quadra.isInCooldown {
+            return "A quadra esta em cooldown. Planeje a proxima investida quando a janela territorial reabrir."
+        }
+        if quadra.shield < 40 {
+            return "O escudo esta baixo e o dominio pode virar rapido. Se a quadra for estrategica, vale competir."
+        }
+        return "O dominio esta consolidado. Vale defender se o ponto for critico ou buscar alvos mais frageis no entorno."
     }
 
     private func shieldColor(for value: Int) -> Color {

--- a/ios/LigaRun/Sources/LigaRun/Features/Map/MapViewModel.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Map/MapViewModel.swift
@@ -7,6 +7,11 @@ struct QuadraStateSummary: Equatable {
     let disputed: Int
 }
 
+struct MapEmptyState: Equatable {
+    let title: String
+    let message: String
+}
+
 @MainActor
 final class MapViewModel: ObservableObject {
     @Published var quadras: [Quadra] = []
@@ -14,12 +19,17 @@ final class MapViewModel: ObservableObject {
     @Published var focusCoordinate: CLLocationCoordinate2D?
     @Published var isLoading = false
     @Published var errorMessage: String?
+    @Published private(set) var activeFilter: MapOwnershipFilter = .all
+    @Published private(set) var emptyState: MapEmptyState?
+    @Published private(set) var contextualMessage: String?
 
     private let api: MapAPIProviding
+    private let currentUserProvider: () -> User?
     private var lastVisibleBounds: (minLat: Double, minLng: Double, maxLat: Double, maxLng: Double)?
 
     init(session: SessionStore, api: MapAPIProviding? = nil) {
         self.api = api ?? session.api
+        self.currentUserProvider = { session.currentUser }
     }
 
     var quadraStateSummary: QuadraStateSummary {
@@ -35,30 +45,40 @@ final class MapViewModel: ObservableObject {
         return QuadraStateSummary(neutral: counts.neutral, owned: counts.owned, disputed: counts.disputed)
     }
 
-    func loadQuadras(bounds: (minLat: Double, minLng: Double, maxLat: Double, maxLng: Double)) async {
+    func updateVisibleBounds(
+        _ bounds: (minLat: Double, minLng: Double, maxLat: Double, maxLng: Double),
+        filter: MapOwnershipFilter,
+        focusContext: MapFocusContext? = nil
+    ) async {
+        lastVisibleBounds = bounds
+        guard filter == .all else { return }
+        await selectFilter(filter, focusContext: focusContext)
+    }
+
+    func selectFilter(_ filter: MapOwnershipFilter, focusContext: MapFocusContext? = nil) async {
+        activeFilter = filter
         isLoading = true
         errorMessage = nil
+        emptyState = nil
+        contextualMessage = contextualMessage(for: filter, focusContext: focusContext)
         defer { isLoading = false }
 
         do {
-            quadras = try await api.getQuadras(bounds: bounds)
-            lastVisibleBounds = bounds
+            quadras = try await loadQuadras(for: filter, focusContext: focusContext)
+            emptyState = quadras.isEmpty ? makeEmptyState(for: filter, focusContext: focusContext) : nil
         } catch {
+            quadras = []
             errorMessage = mapErrorMessage(for: error)
         }
     }
 
     func refreshVisibleQuadras() async {
         guard let lastVisibleBounds else { return }
-        await loadQuadras(bounds: lastVisibleBounds)
+        await updateVisibleBounds(lastVisibleBounds, filter: activeFilter)
     }
 
     func refreshDisputedQuadras() async {
-        do {
-            quadras = try await api.getDisputedQuadras()
-        } catch {
-            errorMessage = mapErrorMessage(for: error)
-        }
+        await selectFilter(.disputed)
     }
 
     func focusOnQuadra(id: String) async {
@@ -68,6 +88,101 @@ final class MapViewModel: ObservableObject {
             upsert(quadra: quadra)
         } catch {
             errorMessage = mapErrorMessage(for: error)
+        }
+    }
+
+    private func loadQuadras(
+        for filter: MapOwnershipFilter,
+        focusContext: MapFocusContext?
+    ) async throws -> [Quadra] {
+        switch filter {
+        case .all:
+            guard let lastVisibleBounds else { return quadras }
+            return try await api.getQuadras(bounds: lastVisibleBounds)
+        case .disputed:
+            return try await api.getDisputedQuadras()
+        case .mine:
+            guard let userId = resolvedUserId(from: focusContext) else {
+                return []
+            }
+            return try await api.getQuadrasByUser(userId: userId)
+        case .myBandeira:
+            guard let bandeiraId = resolvedBandeiraId(from: focusContext) else {
+                return []
+            }
+            return try await api.getQuadrasByBandeira(bandeiraId: bandeiraId)
+        }
+    }
+
+    private func resolvedUserId(from focusContext: MapFocusContext?) -> String? {
+        if case let .user(userId) = focusContext {
+            return userId
+        }
+        return currentUserProvider()?.id
+    }
+
+    private func resolvedBandeiraId(from focusContext: MapFocusContext?) -> String? {
+        if case let .bandeira(bandeiraId) = focusContext {
+            return bandeiraId
+        }
+        return currentUserProvider()?.bandeiraId
+    }
+
+    private func makeEmptyState(
+        for filter: MapOwnershipFilter,
+        focusContext: MapFocusContext?
+    ) -> MapEmptyState {
+        switch filter {
+        case .all:
+            return MapEmptyState(
+                title: "Nenhuma quadra visivel",
+                message: "Mova o mapa para outra regiao ou aproxime a camera para carregar novas quadras."
+            )
+        case .disputed:
+            return MapEmptyState(
+                title: "Nenhuma disputa agora",
+                message: "Nao ha quadras em disputa no momento. Tente novamente em instantes ou volte para Todas."
+            )
+        case .mine:
+            if resolvedUserId(from: focusContext) == nil {
+                return MapEmptyState(
+                    title: "Sessao necessaria",
+                    message: "Entre com sua conta para ver apenas as quadras sob seu controle."
+                )
+            }
+            return MapEmptyState(
+                title: "Voce ainda nao domina quadras",
+                message: "Quando conquistar territorio, suas quadras aparecerao aqui sem mudar a camera."
+            )
+        case .myBandeira:
+            if resolvedBandeiraId(from: focusContext) == nil {
+                return MapEmptyState(
+                    title: "Voce ainda nao tem bandeira",
+                    message: "Entre em uma bandeira no hub social para liberar esse filtro e acompanhar o territorio coletivo."
+                )
+            }
+            return MapEmptyState(
+                title: "Nenhuma quadra dessa bandeira",
+                message: "A bandeira filtrada ainda nao domina quadras nessa visao. Troque o filtro ou volte para Todas."
+            )
+        }
+    }
+
+    private func contextualMessage(
+        for filter: MapOwnershipFilter,
+        focusContext: MapFocusContext?
+    ) -> String? {
+        guard let currentUser = currentUserProvider() else { return nil }
+
+        switch (filter, focusContext) {
+        case let (.mine, .user(userId)) where userId != currentUser.id:
+            return "Exibindo as quadras do corredor selecionado no fluxo social."
+        case let (.myBandeira, .bandeira(bandeiraId)) where bandeiraId != currentUser.bandeiraId:
+            return "Exibindo o territorio da bandeira selecionada no hub social."
+        case (.myBandeira, _) where currentUser.bandeiraId == nil:
+            return "Sem bandeira ativa: o filtro mostra um estado orientativo em vez de erro seco."
+        default:
+            return nil
         }
     }
 

--- a/ios/LigaRun/Sources/LigaRun/Features/Runs/ActiveRunHUD.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Runs/ActiveRunHUD.swift
@@ -43,7 +43,7 @@ struct ActiveRunHUD: View {
                 showsUserLocation: true,
                 styleURI: .standard,
                 onVisibleRegionChanged: { bounds in
-                    Task { await mapViewModel.loadQuadras(bounds: bounds.toTuple) }
+                    Task { await mapViewModel.updateVisibleBounds(bounds.toTuple, filter: .all) }
                 }
             )
             .ignoresSafeArea()

--- a/ios/LigaRun/Tests/LigaRunTests/MapViewModelTests.swift
+++ b/ios/LigaRun/Tests/LigaRunTests/MapViewModelTests.swift
@@ -3,47 +3,192 @@ import XCTest
 
 final class MapViewModelTests: XCTestCase {
     @MainActor
-    func testLoadQuadrasRefreshesQuadraList() async {
-        let tiles = [makeQuadraFixture(id: "tile-a"), makeQuadraFixture(id: "tile-b", isInDispute: true)]
+    func testUpdateVisibleBoundsLoadsViewportForAllFilter() async {
+        let bounds = (minLat: -26.0, minLng: -50.0, maxLat: -25.0, maxLng: -49.0)
         let api = MapAPISpy(
-            quadrasResult: .success(tiles),
+            viewportQuadrasResult: .success([makeQuadraFixture(id: "tile-a"), makeQuadraFixture(id: "tile-b", isInDispute: true)]),
             disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(makeQuadraFixture())
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.loadQuadras(bounds: (minLat: -26, minLng: -50, maxLat: -25, maxLng: -49))
+        await viewModel.updateVisibleBounds(bounds, filter: .all)
 
+        XCTAssertEqual(api.getQuadrasCallCount, 1)
+        XCTAssertEqual(api.lastBounds?.minLat, bounds.minLat)
         XCTAssertEqual(viewModel.quadras.map(\.id), ["tile-a", "tile-b"])
+        XCTAssertEqual(viewModel.activeFilter, .all)
         XCTAssertNil(viewModel.errorMessage)
+        XCTAssertNil(viewModel.emptyState)
         XCTAssertFalse(viewModel.isLoading)
     }
 
     @MainActor
-    func testRefreshDisputedUpdatesTiles() async {
-        let disputed = [makeQuadraFixture(id: "tile-dispute", isInDispute: true)]
+    func testSelectDisputedLoadsDedicatedEndpoint() async {
         let api = MapAPISpy(
-            quadrasResult: .success([]),
-            disputedQuadrasResult: .success(disputed),
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([makeQuadraFixture(id: "tile-dispute", isInDispute: true)]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(makeQuadraFixture())
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.refreshDisputedQuadras()
+        await viewModel.selectFilter(.disputed)
 
+        XCTAssertEqual(api.getDisputedQuadrasCallCount, 1)
+        XCTAssertEqual(viewModel.activeFilter, .disputed)
         XCTAssertEqual(viewModel.quadras.first?.id, "tile-dispute")
         XCTAssertTrue(viewModel.quadras.first?.isInDispute ?? false)
+        XCTAssertNil(viewModel.emptyState)
+    }
+
+    @MainActor
+    func testSelectMineLoadsCurrentUserQuadras() async {
+        let session = makeSessionStore(user: makeMapUserFixture(id: "runner-1", bandeiraId: nil))
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([makeQuadraFixture(id: "mine-1", ownerId: "runner-1")]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: session, api: api)
+
+        await viewModel.selectFilter(.mine)
+
+        XCTAssertEqual(api.getQuadrasByUserCallCount, 1)
+        XCTAssertEqual(api.lastUserId, "runner-1")
+        XCTAssertEqual(viewModel.quadras.map(\.id), ["mine-1"])
+        XCTAssertNil(viewModel.emptyState)
+    }
+
+    @MainActor
+    func testSelectMyBandeiraUsesFocusContextOverride() async {
+        let session = makeSessionStore(user: makeMapUserFixture(id: "runner-1", bandeiraId: "band-own"))
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([makeQuadraFixture(id: "band-quadra", ownerId: "band-ranking", ownerType: .bandeira)]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: session, api: api)
+
+        await viewModel.selectFilter(.myBandeira, focusContext: .bandeira(bandeiraId: "band-ranking"))
+
+        XCTAssertEqual(api.getQuadrasByBandeiraCallCount, 1)
+        XCTAssertEqual(api.lastBandeiraId, "band-ranking")
+        XCTAssertEqual(viewModel.quadras.map(\.id), ["band-quadra"])
+        XCTAssertEqual(viewModel.contextualMessage, "Exibindo o territorio da bandeira selecionada no hub social.")
+    }
+
+    @MainActor
+    func testSelectMineWithoutSessionShowsGuidanceEmptyState() async {
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
+
+        await viewModel.selectFilter(.mine)
+
+        XCTAssertTrue(viewModel.quadras.isEmpty)
+        XCTAssertEqual(viewModel.emptyState?.title, "Sessao necessaria")
+        XCTAssertNil(viewModel.errorMessage)
+        XCTAssertEqual(api.getQuadrasByUserCallCount, 0)
+    }
+
+    @MainActor
+    func testSelectMyBandeiraWithoutBandeiraShowsGuidanceEmptyState() async {
+        let session = makeSessionStore(user: makeMapUserFixture(id: "runner-1", bandeiraId: nil))
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: session, api: api)
+
+        await viewModel.selectFilter(.myBandeira)
+
+        XCTAssertTrue(viewModel.quadras.isEmpty)
+        XCTAssertEqual(viewModel.emptyState?.title, "Voce ainda nao tem bandeira")
+        XCTAssertEqual(viewModel.contextualMessage, "Sem bandeira ativa: o filtro mostra um estado orientativo em vez de erro seco.")
+        XCTAssertEqual(api.getQuadrasByBandeiraCallCount, 0)
+    }
+
+    @MainActor
+    func testSelectDisputedEmptyStateIsUserFacing() async {
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
+
+        await viewModel.selectFilter(.disputed)
+
+        XCTAssertEqual(viewModel.emptyState?.title, "Nenhuma disputa agora")
+        XCTAssertEqual(viewModel.emptyState?.message, "Nao ha quadras em disputa no momento. Tente novamente em instantes ou volte para Todas.")
+    }
+
+    @MainActor
+    func testUpdateVisibleBoundsDoesNotReloadViewportForNonAllFilters() async {
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([makeQuadraFixture(id: "mine-1")]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let session = makeSessionStore(user: makeMapUserFixture(id: "runner-1", bandeiraId: nil))
+        let viewModel = MapViewModel(session: session, api: api)
+
+        await viewModel.updateVisibleBounds((minLat: -26.0, minLng: -50.0, maxLat: -25.0, maxLng: -49.0), filter: .mine)
+
+        XCTAssertEqual(api.getQuadrasCallCount, 0)
+        XCTAssertTrue(viewModel.quadras.isEmpty)
+    }
+
+    @MainActor
+    func testRefreshVisibleQuadrasReusesLastViewportBounds() async {
+        let bounds = (minLat: -26.5, minLng: -50.5, maxLat: -25.5, maxLng: -49.5)
+        let api = MapAPISpy(
+            viewportQuadrasResult: .success([makeQuadraFixture(id: "tile-a"), makeQuadraFixture(id: "tile-b")]),
+            disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
+            quadraResult: .success(makeQuadraFixture())
+        )
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
+
+        await viewModel.updateVisibleBounds(bounds, filter: .all)
+        await viewModel.refreshVisibleQuadras()
+
+        XCTAssertEqual(api.getQuadrasCallCount, 2)
+        XCTAssertEqual(api.lastBounds?.maxLng, bounds.maxLng)
     }
 
     @MainActor
     func testFocusOnQuadraSetsFocusCoordinate() async {
         let tile = makeQuadraFixture(id: "tile-focus", lat: -25.4, lng: -49.3)
         let api = MapAPISpy(
-            quadrasResult: .success([]),
+            viewportQuadrasResult: .success([]),
             disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(tile)
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
         await viewModel.focusOnQuadra(id: "tile-focus")
 
@@ -57,13 +202,15 @@ final class MapViewModelTests: XCTestCase {
         let staleTile = makeQuadraFixture(id: "tile-focus", shield: 10)
         let refreshedTile = makeQuadraFixture(id: "tile-focus", shield: 88, isInDispute: true)
         let api = MapAPISpy(
-            quadrasResult: .success([staleTile]),
+            viewportQuadrasResult: .success([staleTile]),
             disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(refreshedTile)
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.loadQuadras(bounds: (minLat: -26, minLng: -50, maxLat: -25, maxLng: -49))
+        await viewModel.updateVisibleBounds((minLat: -26.0, minLng: -50.0, maxLat: -25.0, maxLng: -49.0), filter: .all)
         await viewModel.focusOnQuadra(id: "tile-focus")
 
         XCTAssertEqual(viewModel.quadras.count, 1)
@@ -72,81 +219,54 @@ final class MapViewModelTests: XCTestCase {
     }
 
     @MainActor
-    func testRefreshVisibleQuadrasUsesLastBounds() async {
-        let tiles = [makeQuadraFixture(id: "tile-a"), makeQuadraFixture(id: "tile-b")]
-        let api = MapAPISpy(
-            quadrasResult: .success(tiles),
-            disputedQuadrasResult: .success([]),
-            quadraResult: .success(makeQuadraFixture())
-        )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
-        let bounds = (minLat: -26.5, minLng: -50.5, maxLat: -25.5, maxLng: -49.5)
-
-        await viewModel.loadQuadras(bounds: bounds)
-        await viewModel.refreshVisibleQuadras()
-
-        XCTAssertEqual(api.getQuadrasCallCount, 2)
-        XCTAssertEqual(api.lastBounds?.minLat, bounds.minLat)
-        XCTAssertEqual(api.lastBounds?.maxLng, bounds.maxLng)
-    }
-
-    @MainActor
     func testQuadraStateSummaryCountsNeutralOwnedAndDisputed() async {
-        let tiles = [
-            makeQuadraFixture(id: "neutral", ownerType: nil, ownerName: nil, ownerColor: nil),
-            makeQuadraFixture(id: "owned", ownerType: .solo),
-            makeQuadraFixture(id: "disputed", ownerType: .bandeira, isInDispute: true)
-        ]
         let api = MapAPISpy(
-            quadrasResult: .success(tiles),
+            viewportQuadrasResult: .success([
+                makeQuadraFixture(id: "neutral", ownerType: nil, ownerName: nil, ownerColor: nil),
+                makeQuadraFixture(id: "owned", ownerType: .solo),
+                makeQuadraFixture(id: "disputed", ownerType: .bandeira, isInDispute: true)
+            ]),
             disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(makeQuadraFixture())
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.loadQuadras(bounds: (minLat: -26, minLng: -50, maxLat: -25, maxLng: -49))
+        await viewModel.updateVisibleBounds((minLat: -26.0, minLng: -50.0, maxLat: -25.0, maxLng: -49.0), filter: .all)
 
         XCTAssertEqual(viewModel.quadraStateSummary, QuadraStateSummary(neutral: 1, owned: 1, disputed: 1))
     }
 
     @MainActor
-    func testLoadQuadrasErrorSetsMessage() async {
+    func testSelectAllErrorSetsFriendlyMessage() async {
         let api = MapAPISpy(
-            quadrasResult: .failure(APIError(error: "MAP_ERROR", message: "Falha no mapa", details: nil)),
+            viewportQuadrasResult: .failure(APIError(error: "MAP_ERROR", message: "Falha no mapa", details: nil)),
             disputedQuadrasResult: .success([]),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(makeQuadraFixture())
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.loadQuadras(bounds: (minLat: -26, minLng: -50, maxLat: -25, maxLng: -49))
+        await viewModel.updateVisibleBounds((minLat: -26.0, minLng: -50.0, maxLat: -25.0, maxLng: -49.0), filter: .all)
 
         XCTAssertEqual(viewModel.errorMessage, "Falha no mapa")
+        XCTAssertTrue(viewModel.quadras.isEmpty)
     }
 
     @MainActor
-    func testLoadQuadrasBadServerResponseSetsFriendlyMessage() async {
+    func testSelectDisputedTimedOutSetsFriendlyMessage() async {
         let api = MapAPISpy(
-            quadrasResult: .failure(URLError(.badServerResponse)),
-            disputedQuadrasResult: .success([]),
-            quadraResult: .success(makeQuadraFixture())
-        )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
-
-        await viewModel.loadQuadras(bounds: (minLat: -26, minLng: -50, maxLat: -25, maxLng: -49))
-
-        XCTAssertEqual(viewModel.errorMessage, "Serviço de mapa indisponível no momento. Tente novamente em instantes.")
-    }
-
-    @MainActor
-    func testRefreshDisputedQuadrasTimedOutSetsFriendlyMessage() async {
-        let api = MapAPISpy(
-            quadrasResult: .success([]),
+            viewportQuadrasResult: .success([]),
             disputedQuadrasResult: .failure(URLError(.timedOut)),
+            userQuadrasResult: .success([]),
+            bandeiraQuadrasResult: .success([]),
             quadraResult: .success(makeQuadraFixture())
         )
-        let viewModel = MapViewModel(session: SessionStore(), api: api)
+        let viewModel = MapViewModel(session: makeSessionStore(), api: api)
 
-        await viewModel.refreshDisputedQuadras()
+        await viewModel.selectFilter(.disputed)
 
         XCTAssertEqual(viewModel.errorMessage, "A requisição demorou demais. Tente novamente em instantes.")
     }
@@ -154,41 +274,83 @@ final class MapViewModelTests: XCTestCase {
 
 @MainActor
 private final class MapAPISpy: MapAPIProviding {
-    let quadrasResult: Result<[Tile], Error>
+    let viewportQuadrasResult: Result<[Tile], Error>
     let disputedQuadrasResult: Result<[Tile], Error>
+    let userQuadrasResult: Result<[Tile], Error>
+    let bandeiraQuadrasResult: Result<[Tile], Error>
     let quadraResult: Result<Tile, Error>
     private(set) var getQuadrasCallCount = 0
+    private(set) var getDisputedQuadrasCallCount = 0
+    private(set) var getQuadrasByUserCallCount = 0
+    private(set) var getQuadrasByBandeiraCallCount = 0
     private(set) var lastBounds: (minLat: Double, minLng: Double, maxLat: Double, maxLng: Double)?
+    private(set) var lastUserId: String?
+    private(set) var lastBandeiraId: String?
 
     init(
-        quadrasResult: Result<[Tile], Error>,
+        viewportQuadrasResult: Result<[Tile], Error>,
         disputedQuadrasResult: Result<[Tile], Error>,
+        userQuadrasResult: Result<[Tile], Error>,
+        bandeiraQuadrasResult: Result<[Tile], Error>,
         quadraResult: Result<Tile, Error>
     ) {
-        self.quadrasResult = quadrasResult
+        self.viewportQuadrasResult = viewportQuadrasResult
         self.disputedQuadrasResult = disputedQuadrasResult
+        self.userQuadrasResult = userQuadrasResult
+        self.bandeiraQuadrasResult = bandeiraQuadrasResult
         self.quadraResult = quadraResult
     }
 
     func getQuadras(bounds: (minLat: Double, minLng: Double, maxLat: Double, maxLng: Double)) async throws -> [Tile] {
         getQuadrasCallCount += 1
         lastBounds = bounds
-        return try quadrasResult.get()
+        return try viewportQuadrasResult.get()
     }
 
     func getDisputedQuadras() async throws -> [Tile] {
-        try disputedQuadrasResult.get()
+        getDisputedQuadrasCallCount += 1
+        return try disputedQuadrasResult.get()
     }
 
     func getQuadrasByUser(userId: String) async throws -> [Tile] {
-        try quadrasResult.get()
+        getQuadrasByUserCallCount += 1
+        lastUserId = userId
+        return try userQuadrasResult.get()
     }
 
     func getQuadrasByBandeira(bandeiraId: String) async throws -> [Tile] {
-        try quadrasResult.get()
+        getQuadrasByBandeiraCallCount += 1
+        lastBandeiraId = bandeiraId
+        return try bandeiraQuadrasResult.get()
     }
 
     func getQuadra(id: String) async throws -> Tile {
         try quadraResult.get()
     }
+}
+
+@MainActor
+private func makeSessionStore(user: User? = nil) -> SessionStore {
+    let session = SessionStore()
+    session.currentUser = user
+    return session
+}
+
+private func makeMapUserFixture(
+    id: String = "runner-1",
+    bandeiraId: String? = "band-1"
+) -> User {
+    User(
+        id: id,
+        email: "\(id)@ligarun.app",
+        username: id,
+        avatarUrl: nil,
+        isPublic: true,
+        bandeiraId: bandeiraId,
+        bandeiraName: bandeiraId.map { _ in "Liga" },
+        role: "runner",
+        totalRuns: 0,
+        totalDistance: 0,
+        totalTilesConquered: 0
+    )
 }

--- a/ios/LigaRun/Tests/LigaRunTests/MapViewModelTests.swift
+++ b/ios/LigaRun/Tests/LigaRunTests/MapViewModelTests.swift
@@ -72,7 +72,7 @@ final class MapViewModelTests: XCTestCase {
             viewportQuadrasResult: .success([]),
             disputedQuadrasResult: .success([]),
             userQuadrasResult: .success([]),
-            bandeiraQuadrasResult: .success([makeQuadraFixture(id: "band-quadra", ownerId: "band-ranking", ownerType: .bandeira)]),
+            bandeiraQuadrasResult: .success([makeQuadraFixture(id: "band-quadra", ownerType: .bandeira, ownerId: "band-ranking")]),
             quadraResult: .success(makeQuadraFixture())
         )
         let viewModel = MapViewModel(session: session, api: api)


### PR DESCRIPTION
## Summary
- add ownership filters and contextual empty states to the map flow
- route viewport, disputed, user and bandeira quadras through dedicated loading paths
- align ActiveRunHUD with the new map filter API

## Testing
- MapViewModelTests
- SessionStoreSharedStateTests, APIClientRequestTests, BandeirasViewModelTests, MapViewModelTests, ProfileViewModelTests

Closes #81