### PR TITLE
feat(ios): add team roster and role management

### DIFF
--- a/ios/LigaRun/Sources/LigaRun/Features/Bandeiras/BandeirasView.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Bandeiras/BandeirasView.swift
@@ -82,7 +82,7 @@ struct BandeirasView: View {
         case .ranking:
             rankingContent
         case .myTeam:
-            myTeamPlaceholderContent
+            myTeamContent
         }
     }
 
@@ -223,22 +223,109 @@ struct BandeirasView: View {
         }
     }
 
-    private var myTeamPlaceholderContent: some View {
-        Section("Minha equipe") {
-            VStack(alignment: .leading, spacing: 12) {
-                Label("Superficie reservada para o passo 05", systemImage: "person.3.fill")
-                    .font(.headline)
-
-                Text(myTeamPlaceholderMessage)
-                    .font(.subheadline)
-                    .foregroundColor(.secondary)
-
-                Button(viewModel.currentBandeiraId == nil ? "Ir para Explorar" : "Ver ranking atual") {
-                    session.activeBandeirasHubTab = viewModel.currentBandeiraId == nil ? .explore : .ranking
+    private var myTeamContent: some View {
+        Group {
+            if viewModel.currentBandeiraId == nil {
+                surfaceMessageSection(
+                    title: "Entre em uma bandeira para montar sua equipe",
+                    message: "Use Explorar para entrar em uma bandeira e habilitar roster, top contribuidores e administracao de roles.",
+                    symbol: "person.3.sequence.fill",
+                    tint: .secondary,
+                    actionTitle: "Ir para Explorar"
+                ) {
+                    session.activeBandeirasHubTab = .explore
                 }
-                .buttonStyle(.bordered)
+            } else {
+                Section("Minha equipe") {
+                    VStack(alignment: .leading, spacing: 12) {
+                        HStack(alignment: .top) {
+                            VStack(alignment: .leading, spacing: 6) {
+                                Text(viewModel.currentBandeiraName ?? "Minha equipe")
+                                    .font(.headline)
+                                Text("Gerencie contribuidores, acompanhe o roster e ajuste roles sem sair do hub.")
+                                    .font(.subheadline)
+                                    .foregroundColor(.secondary)
+                            }
+
+                            Spacer()
+
+                            tag(
+                                viewModel.canManageTeamRoles ? "Admin" : "Membro",
+                                tint: viewModel.canManageTeamRoles ? .orange : .secondary
+                            )
+                        }
+
+                        HStack(spacing: 12) {
+                            Label("\(viewModel.teamMembers.count) membros", systemImage: "person.3.fill")
+                            Label("\(viewModel.teamTotalConquests) quadras", systemImage: "map.fill")
+                            Label("\(viewModel.teamAdminCount) admins", systemImage: "crown.fill")
+                        }
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+
+                        HStack {
+                            Button("Ver territorio") {
+                                viewModel.requestMapFocusForCurrentTeam()
+                            }
+                            .buttonStyle(.borderedProminent)
+
+                            Button("Abrir ranking") {
+                                session.activeBandeirasHubTab = .ranking
+                            }
+                            .buttonStyle(.bordered)
+                        }
+                    }
+                    .padding(.vertical, 4)
+                }
+
+                if let errorMessage = viewModel.teamErrorMessage {
+                    surfaceMessageSection(
+                        title: "Nao foi possivel carregar sua equipe",
+                        message: errorMessage,
+                        symbol: "person.3.sequence.fill",
+                        tint: .orange,
+                        actionTitle: "Recarregar equipe"
+                    ) {
+                        await viewModel.loadMyTeam()
+                    }
+                }
+
+                if viewModel.isTeamLoading && viewModel.teamMembers.isEmpty {
+                    Section {
+                        ProgressView("Carregando equipe...")
+                            .frame(maxWidth: .infinity, alignment: .center)
+                            .padding(.vertical, 12)
+                    }
+                }
+
+                if viewModel.shouldShowTeamEmptyState {
+                    surfaceMessageSection(
+                        title: viewModel.teamEmptyStateTitle,
+                        message: viewModel.teamEmptyStateMessage,
+                        symbol: "person.crop.circle.badge.exclamationmark",
+                        tint: .secondary,
+                        actionTitle: "Atualizar equipe"
+                    ) {
+                        await viewModel.loadMyTeam()
+                    }
+                } else {
+                    if !viewModel.topContributors.isEmpty {
+                        Section("Top contribuidores") {
+                            ForEach(Array(viewModel.topContributors.enumerated()), id: \.element.id) { index, member in
+                                contributorHighlightRow(for: member, position: index + 1)
+                            }
+                        }
+                    }
+
+                    if !viewModel.sortedTeamMembers.isEmpty {
+                        Section("Roster completo") {
+                            ForEach(viewModel.sortedTeamMembers) { member in
+                                teamMemberRow(for: member)
+                            }
+                        }
+                    }
+                }
             }
-            .padding(.vertical, 8)
         }
     }
 
@@ -343,6 +430,86 @@ struct BandeirasView: View {
         .padding(.vertical, 6)
     }
 
+    private func contributorHighlightRow(for member: BandeiraMember, position: Int) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(highlightColor(for: position).opacity(0.18))
+                    Image(systemName: highlightSymbol(for: position))
+                        .foregroundColor(highlightColor(for: position))
+                }
+                .frame(width: 38, height: 38)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(member.username)
+                            .font(.headline)
+                        if member.id == viewModel.currentUserId {
+                            tag("Voce", tint: .blue)
+                        }
+                        tag(viewModel.roleBadgeText(for: member), tint: roleTint(for: member))
+                    }
+
+                    Text("\(member.totalTilesConquered) quadras conquistadas")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
+    private func teamMemberRow(for member: BandeiraMember) -> some View {
+        VStack(alignment: .leading, spacing: 10) {
+            HStack(alignment: .top, spacing: 12) {
+                ZStack {
+                    Circle()
+                        .fill(Color.accentColor.opacity(0.14))
+                    Text(member.username.prefix(1).uppercased())
+                        .font(.headline.weight(.semibold))
+                        .foregroundColor(.accentColor)
+                }
+                .frame(width: 38, height: 38)
+
+                VStack(alignment: .leading, spacing: 6) {
+                    HStack {
+                        Text(member.username)
+                            .font(.headline)
+                        if member.id == viewModel.currentUserId {
+                            tag("Voce", tint: .blue)
+                        }
+                        tag(viewModel.roleBadgeText(for: member), tint: roleTint(for: member))
+                    }
+
+                    Text("\(member.totalTilesConquered) quadras conquistadas")
+                        .font(.caption)
+                        .foregroundColor(.secondary)
+                }
+
+                Spacer()
+
+                if viewModel.roleMutationMemberId == member.id {
+                    ProgressView()
+                        .controlSize(.small)
+                }
+            }
+
+            if let actionTitle = viewModel.roleActionTitle(for: member) {
+                Button(actionTitle) {
+                    Task {
+                        await viewModel.updateRole(for: member)
+                    }
+                }
+                .buttonStyle(.bordered)
+                .disabled(viewModel.roleMutationMemberId != nil)
+            }
+        }
+        .padding(.vertical, 4)
+    }
+
     private func surfaceMessageSection(
         title: String,
         message: String,
@@ -388,15 +555,8 @@ struct BandeirasView: View {
         case .ranking:
             return "Use o ranking para abrir o mapa com o foco territorial correto."
         case .myTeam:
-            return "Gancho reservado para membros e roles na proxima etapa."
+            return "Acompanhe o roster, destaque top contribuidores e gerencie roles quando voce for admin."
         }
-    }
-
-    private var myTeamPlaceholderMessage: String {
-        if viewModel.currentBandeiraId == nil {
-            return "Entre em uma bandeira em Explorar para habilitar o roster e os controles de equipe no passo 05."
-        }
-        return "Sua equipe sera carregada aqui no passo 05, incluindo membros e roles, sem alterar o hub atual."
     }
 
     private var createBandeiraSheet: some View {
@@ -441,6 +601,32 @@ struct BandeirasView: View {
                 }
             }
         }
+    }
+
+    private func highlightColor(for position: Int) -> Color {
+        switch position {
+        case 1:
+            return .yellow
+        case 2:
+            return .gray
+        default:
+            return .brown
+        }
+    }
+
+    private func highlightSymbol(for position: Int) -> String {
+        switch position {
+        case 1:
+            return "crown.fill"
+        case 2:
+            return "medal.fill"
+        default:
+            return "star.fill"
+        }
+    }
+
+    private func roleTint(for member: BandeiraMember) -> Color {
+        viewModel.roleBadgeText(for: member) == "Admin" ? .orange : .secondary
     }
 
     @ViewBuilder

--- a/ios/LigaRun/Sources/LigaRun/Features/Bandeiras/BandeirasViewModel.swift
+++ b/ios/LigaRun/Sources/LigaRun/Features/Bandeiras/BandeirasViewModel.swift
@@ -16,11 +16,13 @@ struct BandeirasMapIntent: Equatable {
 @MainActor
 protocol BandeirasServiceProtocol {
     func getBandeiras() async throws -> [Bandeira]
+    func getBandeiraMembers(id: String) async throws -> [BandeiraMember]
     func getBandeiraRankings() async throws -> [Bandeira]
     func searchBandeiras(query: String) async throws -> [Bandeira]
     func createBandeira(request: CreateBandeiraRequest) async throws -> Bandeira
     func joinBandeira(id: String) async throws -> Bandeira
     func leaveBandeira() async throws
+    func updateMemberRole(bandeiraId: String, request: UpdateBandeiraMemberRoleRequest) async throws -> Bool
 }
 
 @MainActor
@@ -33,6 +35,10 @@ final class BandeirasService: BandeirasServiceProtocol {
 
     func getBandeiras() async throws -> [Bandeira] {
         try await apiClient.getBandeiras()
+    }
+
+    func getBandeiraMembers(id: String) async throws -> [BandeiraMember] {
+        try await apiClient.getBandeiraMembers(id: id)
     }
 
     func getBandeiraRankings() async throws -> [Bandeira] {
@@ -54,12 +60,17 @@ final class BandeirasService: BandeirasServiceProtocol {
     func leaveBandeira() async throws {
         try await apiClient.leaveBandeira()
     }
+
+    func updateMemberRole(bandeiraId: String, request: UpdateBandeiraMemberRoleRequest) async throws -> Bool {
+        try await apiClient.updateMemberRole(bandeiraId: bandeiraId, request: request)
+    }
 }
 
 @MainActor
 final class BandeirasViewModel: ObservableObject {
     @Published var bandeiras: [Bandeira] = []
     @Published var rankingBandeiras: [Bandeira] = []
+    @Published var teamMembers: [BandeiraMember] = []
     @Published var searchQuery: String = ""
     @Published var isMutating = false
     @Published var isCreating = false
@@ -73,13 +84,16 @@ final class BandeirasViewModel: ObservableObject {
     @Published private(set) var currentBandeiraId: String?
     @Published private(set) var exploreStatus: BandeirasSurfaceStatus = .idle
     @Published private(set) var rankingStatus: BandeirasSurfaceStatus = .idle
+    @Published private(set) var teamStatus: BandeirasSurfaceStatus = .idle
     @Published private(set) var pendingMapIntent: BandeirasMapIntent?
+    @Published private(set) var roleMutationMemberId: String?
 
     private let service: BandeirasServiceProtocol
     private let currentUserProvider: () -> User?
     private let refreshUserAction: () async throws -> Void
     private var hasLoadedExplore = false
     private var hasLoadedRanking = false
+    private var hasLoadedTeam = false
 
     init(
         session: SessionStore,
@@ -114,6 +128,10 @@ final class BandeirasViewModel: ObservableObject {
         rankingStatus == .loading
     }
 
+    var isTeamLoading: Bool {
+        teamStatus == .loading
+    }
+
     var exploreErrorMessage: String? {
         message(for: exploreStatus)
     }
@@ -122,12 +140,20 @@ final class BandeirasViewModel: ObservableObject {
         message(for: rankingStatus)
     }
 
+    var teamErrorMessage: String? {
+        message(for: teamStatus)
+    }
+
     var shouldShowExploreEmptyState: Bool {
         exploreStatus == .empty
     }
 
     var shouldShowRankingEmptyState: Bool {
         rankingStatus == .empty
+    }
+
+    var shouldShowTeamEmptyState: Bool {
+        currentBandeiraId != nil && teamStatus == .empty
     }
 
     var exploreEmptyStateTitle: String {
@@ -149,6 +175,49 @@ final class BandeirasViewModel: ObservableObject {
         "Quando houver bandeiras com territorio contabilizado, o ranking aparecera aqui."
     }
 
+    var currentBandeiraName: String? {
+        currentUserProvider()?.bandeiraName
+    }
+
+    var currentUserId: String? {
+        currentUserProvider()?.id
+    }
+
+    var canManageTeamRoles: Bool {
+        normalizedRole(currentUserProvider()?.role) == "ADMIN"
+    }
+
+    var sortedTeamMembers: [BandeiraMember] {
+        teamMembers.sorted { lhs, rhs in
+            if lhs.totalTilesConquered != rhs.totalTilesConquered {
+                return lhs.totalTilesConquered > rhs.totalTilesConquered
+            }
+            return lhs.username.localizedCaseInsensitiveCompare(rhs.username) == .orderedAscending
+        }
+    }
+
+    var topContributors: [BandeiraMember] {
+        Array(sortedTeamMembers.prefix(3))
+    }
+
+    var teamAdminCount: Int {
+        teamMembers.filter { normalizedRole($0.role) == "ADMIN" }.count
+    }
+
+    var teamTotalConquests: Int {
+        teamMembers.reduce(into: 0) { partialResult, member in
+            partialResult += member.totalTilesConquered
+        }
+    }
+
+    var teamEmptyStateTitle: String {
+        "Nenhum membro encontrado"
+    }
+
+    var teamEmptyStateMessage: String {
+        "Sua bandeira ainda nao retornou membros ativos. Atualize a equipe ou confira o backend antes de seguir."
+    }
+
     func activate(tab: BandeirasHubTab) async {
         syncCurrentBandeiraFromSession()
 
@@ -160,7 +229,8 @@ final class BandeirasViewModel: ObservableObject {
             guard !hasLoadedRanking else { return }
             await loadRanking()
         case .myTeam:
-            break
+            guard !hasLoadedTeam else { return }
+            await loadMyTeam()
         }
     }
 
@@ -171,7 +241,7 @@ final class BandeirasViewModel: ObservableObject {
         case .ranking:
             await loadRanking()
         case .myTeam:
-            syncCurrentBandeiraFromSession()
+            await loadMyTeam()
         }
     }
 
@@ -300,6 +370,9 @@ final class BandeirasViewModel: ObservableObject {
             if hasLoadedRanking {
                 await loadRanking(syncFromSession: false)
             }
+            if hasLoadedTeam {
+                await loadMyTeam(syncFromSession: refreshed)
+            }
         } catch {
             errorMessage = makeUserFacingMessage(
                 for: error,
@@ -331,6 +404,9 @@ final class BandeirasViewModel: ObservableObject {
             if hasLoadedRanking {
                 await loadRanking(syncFromSession: false)
             }
+            if hasLoadedTeam {
+                await loadMyTeam(syncFromSession: refreshed)
+            }
         } catch {
             errorMessage = makeUserFacingMessage(
                 for: error,
@@ -355,6 +431,7 @@ final class BandeirasViewModel: ObservableObject {
             currentBandeiraId = nil
             let refreshed = await refreshUserState(fallbackBandeiraId: nil)
             await load(syncFromSession: refreshed)
+            resetTeamState()
             noticeMessage = "Voce saiu da bandeira. A partir da proxima corrida valida, as acoes voltam para sua conta."
             if !refreshed {
                 noticeMessage = "Voce saiu da bandeira. Atualize para sincronizar sua sessao local."
@@ -366,6 +443,89 @@ final class BandeirasViewModel: ObservableObject {
             errorMessage = makeUserFacingMessage(
                 for: error,
                 fallback: "Nao foi possivel sair da bandeira. Tente novamente."
+            )
+        }
+    }
+
+    func loadMyTeam(syncFromSession: Bool = true) async {
+        if syncFromSession {
+            syncCurrentBandeiraFromSession()
+        }
+
+        guard let currentBandeiraId else {
+            resetTeamState()
+            hasLoadedTeam = true
+            return
+        }
+
+        teamStatus = .loading
+        defer {
+            hasLoadedTeam = true
+        }
+
+        do {
+            teamMembers = try await service.getBandeiraMembers(id: currentBandeiraId)
+            teamStatus = teamMembers.isEmpty ? .empty : .loaded
+        } catch {
+            teamStatus = .failed(
+                makeUserFacingMessage(
+                    for: error,
+                    fallback: "Nao foi possivel carregar sua equipe. Tente novamente."
+                )
+            )
+        }
+    }
+
+    func requestMapFocusForCurrentTeam() {
+        guard let currentBandeiraId else { return }
+        pendingMapIntent = BandeirasMapIntent(
+            filter: .myBandeira,
+            focusContext: .bandeira(bandeiraId: currentBandeiraId)
+        )
+    }
+
+    func roleActionTitle(for member: BandeiraMember) -> String? {
+        guard canManageTeamRoles else { return nil }
+        return normalizedRole(member.role) == "ADMIN" ? "Tornar membro" : "Promover a admin"
+    }
+
+    func roleBadgeText(for member: BandeiraMember) -> String {
+        normalizedRole(member.role) == "ADMIN" ? "Admin" : "Membro"
+    }
+
+    func updateRole(for member: BandeiraMember) async {
+        guard canManageTeamRoles, let currentBandeiraId, roleMutationMemberId == nil else { return }
+
+        let targetRole = normalizedRole(member.role) == "ADMIN" ? "MEMBER" : "ADMIN"
+        errorMessage = nil
+        noticeMessage = nil
+        roleMutationMemberId = member.id
+        defer {
+            roleMutationMemberId = nil
+        }
+
+        do {
+            _ = try await service.updateMemberRole(
+                bandeiraId: currentBandeiraId,
+                request: UpdateBandeiraMemberRoleRequest(userId: member.id, role: targetRole)
+            )
+
+            let refreshed = await refreshUserState(fallbackBandeiraId: currentBandeiraId)
+            await loadMyTeam(syncFromSession: refreshed)
+
+            if targetRole == "ADMIN" {
+                noticeMessage = "\(member.username) agora pode gerenciar roles da equipe."
+            } else {
+                noticeMessage = "\(member.username) voltou para a role de membro."
+            }
+
+            if !refreshed {
+                noticeMessage = "\(noticeMessage ?? "Role atualizada.") Atualize para sincronizar sua sessao local."
+            }
+        } catch {
+            errorMessage = makeUserFacingMessage(
+                for: error,
+                fallback: "Nao foi possivel atualizar a role da equipe. Tente novamente."
             )
         }
     }
@@ -387,6 +547,12 @@ final class BandeirasViewModel: ObservableObject {
 
     private func syncCurrentBandeiraFromSession() {
         currentBandeiraId = currentUserProvider()?.bandeiraId
+    }
+
+    private func resetTeamState() {
+        teamMembers = []
+        teamStatus = .idle
+        roleMutationMemberId = nil
     }
 
     @discardableResult
@@ -434,6 +600,10 @@ final class BandeirasViewModel: ObservableObject {
         guard color.count == 7, color.hasPrefix("#") else { return false }
         let hexDigits = color.dropFirst()
         return hexDigits.allSatisfy { $0.isHexDigit }
+    }
+
+    private func normalizedRole(_ role: String?) -> String {
+        normalized(role ?? "").uppercased()
     }
 
     private func message(for status: BandeirasSurfaceStatus) -> String? {

--- a/ios/LigaRun/Sources/LigaRun/Networking/APIClient.swift
+++ b/ios/LigaRun/Sources/LigaRun/Networking/APIClient.swift
@@ -17,6 +17,7 @@ protocol MapAPIProviding: Sendable {
 @MainActor
 protocol BandeirasAPIProviding: Sendable {
     func getBandeiras() async throws -> [Bandeira]
+    func getBandeiraMembers(id: String) async throws -> [BandeiraMember]
     func searchBandeiras(query: String) async throws -> [Bandeira]
     func createBandeira(request: CreateBandeiraRequest) async throws -> Bandeira
     func joinBandeira(id: String) async throws -> Bandeira

--- a/ios/LigaRun/Tests/LigaRunTests/APIClientRequestTests.swift
+++ b/ios/LigaRun/Tests/LigaRunTests/APIClientRequestTests.swift
@@ -52,6 +52,25 @@ final class APIClientRequestTests: XCTestCase {
     }
 
     @MainActor
+    func testGetBandeiraMembersRequestsExpectedEndpoint() async throws {
+        let client = makeClient()
+        URLProtocolStub.handler = { request in
+            XCTAssertEqual(request.httpMethod, "GET")
+            XCTAssertEqual(request.url?.path, "/api/bandeiras/band-456/members")
+            XCTAssertEqual(request.value(forHTTPHeaderField: "Authorization"), "Bearer token-123")
+
+            return HTTPStubResponse(
+                statusCode: 200,
+                body: Data("[]".utf8)
+            )
+        }
+
+        let members = try await client.getBandeiraMembers(id: "band-456")
+
+        XCTAssertTrue(members.isEmpty)
+    }
+
+    @MainActor
     func testUpdateMemberRoleSendsExpectedPayload() async throws {
         let client = makeClient()
         let expectedRequest = UpdateBandeiraMemberRoleRequest(userId: "user-789", role: "ADMIN")

--- a/ios/LigaRun/Tests/LigaRunTests/BandeirasViewModelTests.swift
+++ b/ios/LigaRun/Tests/LigaRunTests/BandeirasViewModelTests.swift
@@ -198,21 +198,177 @@ final class BandeirasViewModelTests: XCTestCase {
 
         XCTAssertNil(viewModel.pendingMapIntent)
     }
+
+    @MainActor
+    func testLoadMyTeamSortsContributorsByConquestsAndName() async {
+        let service = BandeirasServiceSpy()
+        service.members = [
+            makeBandeiraMemberFixture(id: "m3", username: "Bruno", role: "MEMBER", totalTilesConquered: 8),
+            makeBandeiraMemberFixture(id: "m2", username: "Ana", role: "ADMIN", totalTilesConquered: 12),
+            makeBandeiraMemberFixture(id: "m1", username: "Caio", role: "MEMBER", totalTilesConquered: 12),
+            makeBandeiraMemberFixture(id: "m4", username: "Duda", role: "MEMBER", totalTilesConquered: 2)
+        ]
+
+        let viewModel = BandeirasViewModel(
+            service: service,
+            currentUserProvider: {
+                makeUserFixture(
+                    id: "admin-1",
+                    bandeiraId: "band-1",
+                    bandeiraName: "Liga Centro",
+                    role: "ADMIN"
+                )
+            },
+            refreshUserAction: { () async throws in }
+        )
+
+        await viewModel.loadMyTeam()
+
+        XCTAssertEqual(viewModel.teamStatus, .loaded)
+        XCTAssertEqual(viewModel.sortedTeamMembers.map(\.id), ["m2", "m1", "m3", "m4"])
+        XCTAssertEqual(viewModel.topContributors.map(\.id), ["m2", "m1", "m3"])
+        XCTAssertEqual(viewModel.teamAdminCount, 1)
+        XCTAssertEqual(viewModel.teamTotalConquests, 34)
+    }
+
+    @MainActor
+    func testLoadMyTeamWithoutBandeiraResetsSurface() async {
+        let service = BandeirasServiceSpy()
+        service.members = [makeBandeiraMemberFixture()]
+        let viewModel = BandeirasViewModel(
+            service: service,
+            currentUserProvider: {
+                makeUserFixture(
+                    id: "runner-1",
+                    bandeiraId: nil,
+                    bandeiraName: nil,
+                    role: "USER"
+                )
+            },
+            refreshUserAction: { () async throws in }
+        )
+
+        await viewModel.loadMyTeam()
+
+        XCTAssertEqual(viewModel.teamStatus, .idle)
+        XCTAssertTrue(viewModel.teamMembers.isEmpty)
+        XCTAssertEqual(service.getMembersCalls, [])
+    }
+
+    @MainActor
+    func testUpdateRolePromotesMemberAndReloadsTeam() async {
+        let service = BandeirasServiceSpy()
+        service.members = [makeBandeiraMemberFixture(id: "member-1", username: "Pat", role: "MEMBER", totalTilesConquered: 3)]
+        service.updatedMembers = [makeBandeiraMemberFixture(id: "member-1", username: "Pat", role: "ADMIN", totalTilesConquered: 3)]
+
+        var refreshCalls = 0
+        let viewModel = BandeirasViewModel(
+            service: service,
+            currentUserProvider: {
+                makeUserFixture(
+                    id: "admin-1",
+                    bandeiraId: "band-1",
+                    bandeiraName: "Liga Centro",
+                    role: "ADMIN"
+                )
+            },
+            refreshUserAction: { () async throws in
+                refreshCalls += 1
+            }
+        )
+
+        await viewModel.loadMyTeam()
+        await viewModel.updateRole(for: service.members[0])
+
+        XCTAssertEqual(service.updatedRoleRequests.count, 1)
+        XCTAssertEqual(service.updatedRoleRequests.first?.bandeiraId, "band-1")
+        XCTAssertEqual(
+            service.updatedRoleRequests.first?.request,
+            UpdateBandeiraMemberRoleRequest(userId: "member-1", role: "ADMIN")
+        )
+        XCTAssertEqual(service.getMembersCalls, ["band-1", "band-1"])
+        XCTAssertEqual(viewModel.teamMembers.first?.role, "ADMIN")
+        XCTAssertEqual(viewModel.noticeMessage, "Pat agora pode gerenciar roles da equipe.")
+        XCTAssertEqual(refreshCalls, 1)
+        XCTAssertNil(viewModel.errorMessage)
+    }
+
+    @MainActor
+    func testUpdateRoleFailureSurfacesBackendMessage() async {
+        let service = BandeirasServiceSpy()
+        let member = makeBandeiraMemberFixture(id: "member-1", username: "Pat", role: "ADMIN", totalTilesConquered: 3)
+        service.members = [member]
+        service.updateRoleError = APIError(error: "LAST_ADMIN", message: "Voce nao pode remover o ultimo admin.", details: nil)
+
+        let viewModel = BandeirasViewModel(
+            service: service,
+            currentUserProvider: {
+                makeUserFixture(
+                    id: "admin-1",
+                    bandeiraId: "band-1",
+                    bandeiraName: "Liga Centro",
+                    role: "ADMIN"
+                )
+            },
+            refreshUserAction: { () async throws in }
+        )
+
+        await viewModel.loadMyTeam()
+        await viewModel.updateRole(for: member)
+
+        XCTAssertEqual(viewModel.errorMessage, "Voce nao pode remover o ultimo admin.")
+        XCTAssertEqual(viewModel.roleMutationMemberId, nil)
+        XCTAssertEqual(service.updatedRoleRequests.count, 1)
+    }
+
+    @MainActor
+    func testRoleActionTitleIsHiddenForNonAdminUser() async {
+        let member = makeBandeiraMemberFixture(id: "member-1", username: "Pat", role: "MEMBER", totalTilesConquered: 3)
+        let viewModel = BandeirasViewModel(
+            service: BandeirasServiceSpy(),
+            currentUserProvider: {
+                makeUserFixture(
+                    id: "runner-1",
+                    bandeiraId: "band-1",
+                    bandeiraName: "Liga Centro",
+                    role: "MEMBER"
+                )
+            },
+            refreshUserAction: { () async throws in }
+        )
+
+        XCTAssertFalse(viewModel.canManageTeamRoles)
+        XCTAssertNil(viewModel.roleActionTitle(for: member))
+    }
 }
 
 @MainActor
 private final class BandeirasServiceSpy: BandeirasServiceProtocol {
     var bandeiras: [Bandeira] = []
     var rankings: [Bandeira] = []
+    var members: [BandeiraMember] = []
+    var updatedMembers: [BandeiraMember]?
     var joinError: Error?
     var rankingsError: Error?
+    var membersError: Error?
+    var updateRoleError: Error?
     var rankingGate: AsyncGate?
     private(set) var createdRequests: [CreateBandeiraRequest] = []
     private(set) var joinCalls: [String] = []
+    private(set) var getMembersCalls: [String] = []
+    private(set) var updatedRoleRequests: [(bandeiraId: String, request: UpdateBandeiraMemberRoleRequest)] = []
     private(set) var leaveCalls = 0
 
     func getBandeiras() async throws -> [Bandeira] {
         bandeiras
+    }
+
+    func getBandeiraMembers(id: String) async throws -> [BandeiraMember] {
+        getMembersCalls.append(id)
+        if let membersError {
+            throw membersError
+        }
+        return members
     }
 
     func getBandeiraRankings() async throws -> [Bandeira] {
@@ -245,6 +401,17 @@ private final class BandeirasServiceSpy: BandeirasServiceProtocol {
     func leaveBandeira() async throws {
         leaveCalls += 1
     }
+
+    func updateMemberRole(bandeiraId: String, request: UpdateBandeiraMemberRoleRequest) async throws -> Bool {
+        updatedRoleRequests.append((bandeiraId: bandeiraId, request: request))
+        if let updateRoleError {
+            throw updateRoleError
+        }
+        if let updatedMembers {
+            members = updatedMembers
+        }
+        return true
+    }
 }
 
 private actor AsyncGate {
@@ -260,4 +427,40 @@ private actor AsyncGate {
         continuation?.resume()
         continuation = nil
     }
+}
+
+private func makeBandeiraMemberFixture(
+    id: String = "member-1",
+    username: String = "Runner",
+    role: String = "MEMBER",
+    totalTilesConquered: Int = 5
+) -> BandeiraMember {
+    BandeiraMember(
+        id: id,
+        username: username,
+        avatarUrl: nil,
+        role: role,
+        totalTilesConquered: totalTilesConquered
+    )
+}
+
+private func makeUserFixture(
+    id: String,
+    bandeiraId: String?,
+    bandeiraName: String?,
+    role: String
+) -> User {
+    User(
+        id: id,
+        email: "\(id)@example.com",
+        username: id,
+        avatarUrl: nil,
+        isPublic: true,
+        bandeiraId: bandeiraId,
+        bandeiraName: bandeiraName,
+        role: role,
+        totalRuns: 0,
+        totalDistance: 0,
+        totalTilesConquered: 0
+    )
 }


### PR DESCRIPTION
## Summary
- add the Minha equipe surface to the Bandeiras hub
- load and sort roster members with role-aware management actions
- cover member endpoint and role mutation requests in tests

## Testing
- APIClientRequestTests, BandeirasViewModelTests
- SessionStoreSharedStateTests, APIClientRequestTests, BandeirasViewModelTests, MapViewModelTests, ProfileViewModelTests

Closes #83