### PR TITLE
fix(frontend): padroniza textos em PT-BR

### DIFF
--- a/frontend/src/app/(auth)/login/page.test.tsx
+++ b/frontend/src/app/(auth)/login/page.test.tsx
@@ -101,7 +101,7 @@ describe('LoginPage', () => {
                     provider: 'google',
                     emailMasked: 'u***@example.com',
                 },
-                'Vinculo necessario'
+                'Vínculo necessário'
             )
         )
 
@@ -112,7 +112,7 @@ describe('LoginPage', () => {
         expect(
             await screen.findByRole('heading', { name: 'Confirme sua conta para continuar com Google' })
         ).toBeInTheDocument()
-        expect(screen.getByText('Acao necessaria')).toBeInTheDocument()
+        expect(screen.getByText('Ação necessária')).toBeInTheDocument()
         expect(screen.getByText('3. Clique em Vincular e entrar.')).toBeInTheDocument()
         expect(screen.getByPlaceholderText('Email da conta existente')).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Vincular e entrar' })).toBeInTheDocument()

--- a/frontend/src/app/(auth)/login/page.tsx
+++ b/frontend/src/app/(auth)/login/page.tsx
@@ -112,7 +112,7 @@ export default function LoginPage() {
                         <Link href="/" className={styles.logo}>
                             <span className={styles.logoAccent}>Liga</span>Run
                         </Link>
-                        <span className={styles.eyebrow}>Painel Analitico</span>
+                        <span className={styles.eyebrow}>Painel Analítico</span>
                         <h2 className={styles.asideTitle}>
                             Volte para o comando da sua rotina.
                         </h2>
@@ -124,15 +124,15 @@ export default function LoginPage() {
 
                     <div className={styles.asideList}>
                         <div className={styles.asideItem}>
-                            <strong>Visao do corredor</strong>
-                            <span>Distancia, ritmo, consistencia e impacto territorial.</span>
+                            <strong>Visão do corredor</strong>
+                            <span>Distância, ritmo, consistência e impacto territorial.</span>
                         </div>
                         <div className={styles.asideItem}>
-                            <strong>Visao da bandeira</strong>
-                            <span>Membros ativos, ranking e presenca por categoria.</span>
+                            <strong>Visão da bandeira</strong>
+                            <span>Membros ativos, ranking e presença por categoria.</span>
                         </div>
                         <div className={styles.asideItem}>
-                            <strong>Visao de crescimento</strong>
+                            <strong>Visão de crescimento</strong>
                             <span>Um funil claro para atrair novos grupos, crews e assessorias.</span>
                         </div>
                     </div>
@@ -211,7 +211,7 @@ export default function LoginPage() {
 
                     <div className={styles.footer}>
                         <p>
-                            Nao tem uma conta? <Link href="/register">Criar conta</Link>
+                            Não tem uma conta? <Link href="/register">Criar conta</Link>
                         </p>
                     </div>
                 </div>

--- a/frontend/src/app/(auth)/register/page.test.tsx
+++ b/frontend/src/app/(auth)/register/page.test.tsx
@@ -58,7 +58,7 @@ describe('RegisterPage', () => {
         render(<RegisterPage />)
 
         await user.type(screen.getByLabelText('Email'), 'user@example.com')
-        await user.type(screen.getByLabelText('Nome de usuario'), 'runner')
+        await user.type(screen.getByLabelText('Nome de usuário'), 'runner')
         await user.type(screen.getByLabelText('Senha'), 'secret1')
         await user.type(screen.getByLabelText('Confirmar senha'), 'secret1')
         await user.click(screen.getByRole('button', { name: 'Criar conta' }))
@@ -80,7 +80,7 @@ describe('RegisterPage', () => {
                     provider: 'google',
                     emailMasked: 'u***@example.com',
                 },
-                'Vinculo necessario'
+                'Vínculo necessário'
             )
         )
 
@@ -91,7 +91,7 @@ describe('RegisterPage', () => {
         expect(
             await screen.findByRole('heading', { name: 'Confirme sua conta para continuar com Google' })
         ).toBeInTheDocument()
-        expect(screen.getByText('Acao necessaria')).toBeInTheDocument()
+        expect(screen.getByText('Ação necessária')).toBeInTheDocument()
         expect(screen.getByText('2. Informe a senha atual dessa conta.')).toBeInTheDocument()
         expect(screen.getByPlaceholderText('Senha atual da conta')).toBeInTheDocument()
         expect(screen.getByRole('button', { name: 'Vincular e entrar' })).toBeInTheDocument()

--- a/frontend/src/app/(auth)/register/page.tsx
+++ b/frontend/src/app/(auth)/register/page.tsx
@@ -89,7 +89,7 @@ export default function RegisterPage() {
         setError('')
 
         if (password !== confirmPassword) {
-            setError('As senhas nao coincidem')
+            setError('As senhas não coincidem')
             return
         }
 
@@ -99,7 +99,7 @@ export default function RegisterPage() {
         }
 
         if (username.length < 3) {
-            setError('O nome de usuario deve ter pelo menos 3 caracteres')
+            setError('O nome de usuário deve ter pelo menos 3 caracteres')
             return
         }
 
@@ -132,11 +132,11 @@ export default function RegisterPage() {
                         </Link>
                         <span className={styles.eyebrow}>Onboarding</span>
                         <h2 className={styles.asideTitle}>
-                            Leve sua corrida para uma camada mais estrategica.
+                            Leve sua corrida para uma camada mais estratégica.
                         </h2>
                         <p className={styles.asideCopy}>
-                            Crie seu acesso para acompanhar evolucao pessoal,
-                            descobrir bandeiras e abrir espaco para sua crew ou
+                            Crie seu acesso para acompanhar evolução pessoal,
+                            descobrir bandeiras e abrir espaço para sua crew ou
                             assessoria.
                         </p>
                     </div>
@@ -144,11 +144,11 @@ export default function RegisterPage() {
                     <div className={styles.asideList}>
                         <div className={styles.asideItem}>
                             <strong>Corredores</strong>
-                            <span>Centralize historico, metas e consistencia semanal.</span>
+                            <span>Centralize histórico, metas e consistência semanal.</span>
                         </div>
                         <div className={styles.asideItem}>
                             <strong>Grupos</strong>
-                            <span>Mostrem atividade, ranking e presenca territorial.</span>
+                            <span>Mostrem atividade, ranking e presença territorial.</span>
                         </div>
                         <div className={styles.asideItem}>
                             <strong>Assessorias</strong>
@@ -206,7 +206,7 @@ export default function RegisterPage() {
 
                         <div className="form-group">
                             <label className="label" htmlFor="username">
-                                Nome de usuario
+                                Nome de usuário
                             </label>
                             <input
                                 type="text"
@@ -263,7 +263,7 @@ export default function RegisterPage() {
 
                     <div className={styles.footer}>
                         <p>
-                            Ja tem uma conta? <Link href="/login">Entrar</Link>
+                            Já tem uma conta? <Link href="/login">Entrar</Link>
                         </p>
                     </div>
                 </div>

--- a/frontend/src/app/(game)/bandeira/page.tsx
+++ b/frontend/src/app/(game)/bandeira/page.tsx
@@ -54,7 +54,7 @@ export default function BandeiraPage() {
             else failedRequests += 1
 
             if (failedRequests > 0) {
-                setError('Parte da leitura de bandeiras nao carregou. O diretorio segue disponivel.')
+                setError('Parte da leitura de bandeiras não carregou. O diretório segue disponível.')
             }
 
             setLoading(false)
@@ -107,7 +107,7 @@ export default function BandeiraPage() {
             await loadUser()
             router.push('/map')
         } catch {
-            setError('Nao foi possivel entrar na bandeira agora.')
+            setError('Não foi possível entrar na bandeira agora.')
         } finally {
             setJoiningId(null)
         }
@@ -122,7 +122,7 @@ export default function BandeiraPage() {
             await loadUser()
             setMembers([])
         } catch {
-            setError('Nao foi possivel sair da bandeira agora.')
+            setError('Não foi possível sair da bandeira agora.')
         } finally {
             setLeaving(false)
         }
@@ -147,7 +147,7 @@ export default function BandeiraPage() {
                     </h1>
                     <p className="section-copy">
                         Aqui a bandeira deixa de ser um detalhe do jogo. Ela
-                        vira entidade de descoberta, posicionamento e expansao
+                        vira entidade de descoberta, posicionamento e expansão
                         para grupos e assessorias.
                     </p>
                 </div>
@@ -219,7 +219,7 @@ export default function BandeiraPage() {
                                     </span>
                                     <p>
                                         {currentBandeira.description ??
-                                            'Sua equipe ainda nao cadastrou uma descricao publica.'}
+                                            'Sua equipe ainda não cadastrou uma descrição pública.'}
                                     </p>
                                 </div>
 
@@ -236,10 +236,10 @@ export default function BandeiraPage() {
                                         ))
                                     ) : (
                                         <div className="empty-state">
-                                            <strong>Roster ainda nao carregado.</strong>
+                                            <strong>Roster ainda não carregado.</strong>
                                             <span>
                                                 Quando houver membros ativos,
-                                                eles aparecem aqui para leitura rapida.
+                                                eles aparecem aqui para leitura rápida.
                                             </span>
                                         </div>
                                     )}
@@ -251,7 +251,7 @@ export default function BandeiraPage() {
                     <article className="panel">
                         <div className={styles.directoryHeader}>
                             <div className="section-header">
-                                <span className="section-kicker">Diretorio</span>
+                                <span className="section-kicker">Diretório</span>
                                 <h2>Descubra comunidades por nome e categoria.</h2>
                             </div>
 
@@ -295,7 +295,7 @@ export default function BandeiraPage() {
 
                                     <p>
                                         {bandeira.description ??
-                                            'Descricao publica ainda nao cadastrada.'}
+                                            'Descrição pública ainda não cadastrada.'}
                                     </p>
 
                                     <div className={styles.cardMetrics}>
@@ -318,7 +318,7 @@ export default function BandeiraPage() {
                                             {joiningId === bandeira.id ? 'Entrando...' : 'Entrar na bandeira'}
                                         </button>
                                     ) : (
-                                        <span className="tag">Voce ja esta em uma bandeira</span>
+                                        <span className="tag">Você já está em uma bandeira</span>
                                     )}
                                 </article>
                             ))}
@@ -339,7 +339,7 @@ export default function BandeiraPage() {
                     <article className="panel">
                         <div className="section-header">
                             <span className="section-kicker">Mercado local</span>
-                            <h2>Onde estao as oportunidades.</h2>
+                            <h2>Onde estão as oportunidades.</h2>
                         </div>
 
                         <div className="list">
@@ -359,7 +359,7 @@ export default function BandeiraPage() {
 
                     <article className="panel panel-dark">
                         <div className="section-header">
-                            <span className="section-kicker">Atracao</span>
+                            <span className="section-kicker">Atração</span>
                             <h2>Como vender melhor a plataforma.</h2>
                         </div>
                         <div className="list">
@@ -367,7 +367,7 @@ export default function BandeiraPage() {
                                 <div>
                                     <div className="list-title">Assessoria</div>
                                     <div className="list-subtle">
-                                        Precisa de visao coletiva, marca e recorrencia.
+                                        Precisa de visão coletiva, marca e recorrência.
                                     </div>
                                 </div>
                             </div>

--- a/frontend/src/app/(game)/layout.tsx
+++ b/frontend/src/app/(game)/layout.tsx
@@ -9,7 +9,7 @@ import styles from './layout.module.css'
 
 const navItems = [
     { href: '/map', label: 'Painel' },
-    { href: '/run', label: 'Sessoes' },
+    { href: '/run', label: 'Sessões' },
     { href: '/rankings', label: 'Radar' },
     { href: '/bandeira', label: 'Bandeira' },
     { href: '/profile', label: 'Perfil' },
@@ -57,11 +57,11 @@ export default function GameLayout({
                         </Link>
                         <div className={styles.brandCopy}>
                             <span className={styles.brandEyebrow}>Control Center</span>
-                            <p>Corredor, bandeira e expansao local no mesmo painel.</p>
+                            <p>Corredor, bandeira e expansão local no mesmo painel.</p>
                         </div>
                     </div>
 
-                    <nav className={styles.desktopNav} aria-label="Navegacao principal">
+                    <nav className={styles.desktopNav} aria-label="Navegação principal">
                         {navItems.map((item) => (
                             <Link
                                 key={item.href}
@@ -80,7 +80,7 @@ export default function GameLayout({
                             <span className={styles.userLabel}>Corredor</span>
                             <strong>{user?.username}</strong>
                             <span className={styles.userMeta}>
-                                {formatDistance(user?.totalDistance ?? 0)} no historico
+                                {formatDistance(user?.totalDistance ?? 0)} no histórico
                             </span>
                         </div>
 
@@ -101,7 +101,7 @@ export default function GameLayout({
                 <div className="page-shell">{children}</div>
             </main>
 
-            <nav className={styles.bottomNav} aria-label="Navegacao mobile">
+            <nav className={styles.bottomNav} aria-label="Navegação mobile">
                 {navItems.map((item) => (
                     <Link
                         key={item.href}

--- a/frontend/src/app/(game)/map/page.tsx
+++ b/frontend/src/app/(game)/map/page.tsx
@@ -90,7 +90,7 @@ export default function MapPage() {
             else failedRequests += 1
 
             if (failedRequests > 0) {
-                setError('Parte dos indicadores nao carregou. O painel segue com os dados disponiveis.')
+                setError('Parte dos indicadores não carregou. O painel segue com os dados disponíveis.')
             }
 
             setLoading(false)
@@ -141,12 +141,12 @@ export default function MapPage() {
                     <span className="section-kicker">Painel Central</span>
                     <h1 className="section-title">
                         Tudo o que o corredor e a bandeira precisam ler antes
-                        da proxima semana.
+                        da próxima semana.
                     </h1>
                     <p className="section-copy">
-                        O foco aqui nao e iniciar corrida no navegador. E
-                        entender momento, recorrencia, territorio e expansao da
-                        comunidade a partir dos dados que voce ja gera.
+                        O foco aqui não é iniciar corrida no navegador. É
+                        entender momento, recorrência, território e expansão da
+                        comunidade a partir dos dados que você já gera.
                     </p>
 
                     <div className={styles.heroTags}>
@@ -157,7 +157,7 @@ export default function MapPage() {
                             {user?.bandeiraName ?? 'Sem bandeira no momento'}
                         </span>
                         <span className="tag tag-warn">
-                            {territorySnapshot.userActionsRemaining ?? 0} acoes restantes hoje
+                            {territorySnapshot.userActionsRemaining ?? 0} ações restantes hoje
                         </span>
                     </div>
                 </div>
@@ -169,14 +169,14 @@ export default function MapPage() {
                             {formatDistance(runnerSnapshot.weeklyDistance)}
                         </strong>
                         <span className="metric-detail">
-                            {runnerSnapshot.activeDays} dias ativos nos ultimos 7 dias e
-                            ritmo medio de {runnerSnapshot.averagePace}.
+                            {runnerSnapshot.activeDays} dias ativos nos últimos 7 dias e
+                            ritmo médio de {runnerSnapshot.averagePace}.
                         </span>
                     </div>
 
                     <div className={styles.heroAsideList}>
                         <div className={styles.heroAsideItem}>
-                            <span>Ultima sessao</span>
+                            <span>Última sessão</span>
                             <strong>{formatDateLabel(runnerSnapshot.lastRunAt)}</strong>
                         </div>
                         <div className={styles.heroAsideItem}>
@@ -195,7 +195,7 @@ export default function MapPage() {
 
                     <div className={styles.heroAsideActions}>
                         <Link href="/run" className="btn btn-secondary">
-                            Ver sessoes
+                            Ver sessões
                         </Link>
                         <Link href="/bandeira" className="btn btn-outline">
                             Abrir hub de bandeiras
@@ -208,12 +208,12 @@ export default function MapPage() {
 
             <section className="metric-grid">
                 <article className="panel metric-card">
-                    <span className="metric-label">Distancia total</span>
+                    <span className="metric-label">Distância total</span>
                     <strong className="metric-value">
                         {formatDistance(runnerSnapshot.totalDistance)}
                     </strong>
                     <span className="metric-detail">
-                        Historico do corredor consolidado para leitura rapida.
+                        Histórico do corredor consolidado para leitura rápida.
                     </span>
                 </article>
                 <article className="panel metric-card">
@@ -222,16 +222,16 @@ export default function MapPage() {
                         {formatPercentage(runnerSnapshot.validatedRate)}
                     </strong>
                     <span className="metric-detail">
-                        Taxa de sessoes aprovadas na analise de consistencia.
+                        Taxa de sessões aprovadas na análise de consistência.
                     </span>
                 </article>
                 <article className="panel metric-card">
-                    <span className="metric-label">Territorio em disputa</span>
+                    <span className="metric-label">Território em disputa</span>
                     <strong className="metric-value">
                         {formatPercentage(territorySnapshot.disputedShare)}
                     </strong>
                     <span className="metric-detail">
-                        Leitura do quanto o mapa esta pedindo resposta da comunidade.
+                        Leitura do quanto o mapa está pedindo resposta da comunidade.
                     </span>
                 </article>
                 <article className="panel metric-card">
@@ -252,7 +252,7 @@ export default function MapPage() {
                             <span className="section-kicker">Mapa Operacional</span>
                             <h2>Leitura territorial sem sair do painel.</h2>
                             <p className="section-copy">
-                                Use o mapa como contexto de decisao, nao como
+                                Use o mapa como contexto de decisão, não como
                                 tela principal do produto.
                             </p>
                         </div>
@@ -267,18 +267,18 @@ export default function MapPage() {
                     <article className="panel">
                         <div className="section-header">
                             <span className="section-kicker">Tile selecionado</span>
-                            <h2>Contexto rapido</h2>
+                            <h2>Contexto rápido</h2>
                         </div>
 
                         {selectedTile ? (
                             <div className={styles.tileDetails}>
                                 <div className={styles.tileRow}>
-                                    <span>Dominio</span>
+                                    <span>Domínio</span>
                                     <strong>{selectedTile.ownerName ?? 'Neutro'}</strong>
                                 </div>
                                 <div className={styles.tileRow}>
                                     <span>Tipo</span>
-                                    <strong>{selectedTile.ownerType ?? 'Disponivel'}</strong>
+                                    <strong>{selectedTile.ownerType ?? 'Disponível'}</strong>
                                 </div>
                                 <div className={styles.tileRow}>
                                     <span>Escudo</span>
@@ -291,7 +291,7 @@ export default function MapPage() {
                                             ? 'Em disputa'
                                             : selectedTile.isInCooldown
                                               ? 'Cooldown'
-                                              : 'Estavel'}
+                                              : 'Estável'}
                                     </strong>
                                 </div>
                             </div>
@@ -300,7 +300,7 @@ export default function MapPage() {
                                 <strong>Selecione um tile no mapa.</strong>
                                 <span>
                                     O painel mostra dados mais completos quando
-                                    voce clica em um territorio.
+                                    você clica em um território.
                                 </span>
                             </div>
                         )}
@@ -308,7 +308,7 @@ export default function MapPage() {
 
                     <article className="panel">
                         <div className="section-header">
-                            <span className="section-kicker">Acoes do dia</span>
+                            <span className="section-kicker">Ações do dia</span>
                             <h2>Capacidade operacional</h2>
                         </div>
                         <div className={styles.tileDetails}>
@@ -325,11 +325,11 @@ export default function MapPage() {
                                 </strong>
                             </div>
                             <div className={styles.tileRow}>
-                                <span>Conquistas validas</span>
+                                <span>Conquistas válidas</span>
                                 <strong>{territorySnapshot.conquestRuns}</strong>
                             </div>
                             <div className={styles.tileRow}>
-                                <span>Defesas validas</span>
+                                <span>Defesas válidas</span>
                                 <strong>{territorySnapshot.defenseRuns}</strong>
                             </div>
                         </div>
@@ -356,9 +356,9 @@ export default function MapPage() {
                         </div>
                         <div className="list-item">
                             <div>
-                                <div className="list-title">Melhor sessao recente</div>
+                                <div className="list-title">Melhor sessão recente</div>
                                 <div className="list-subtle">
-                                    Maior distancia registrada nesta amostra.
+                                    Maior distância registrada nesta amostra.
                                 </div>
                             </div>
                             <strong>{formatDistance(runnerSnapshot.longestRun)}</strong>
@@ -367,7 +367,7 @@ export default function MapPage() {
                             <div>
                                 <div className="list-title">Efeito territorial</div>
                                 <div className="list-subtle">
-                                    Conversao das corridas validadas em acao de mapa.
+                                    Conversão das corridas validadas em ação de mapa.
                                 </div>
                             </div>
                             <strong>{formatPercentage(runnerSnapshot.territoryConversion)}</strong>
@@ -378,14 +378,14 @@ export default function MapPage() {
                 <article className="panel">
                     <div className="section-header">
                         <span className="section-kicker">Leitura da bandeira</span>
-                        <h2>Peso coletivo e recorrencia da equipe.</h2>
+                        <h2>Peso coletivo e recorrência da equipe.</h2>
                     </div>
 
                     {user?.bandeiraName ? (
                         <div className="list">
                             <div className="list-item">
                                 <div>
-                                    <div className="list-title">Posicao no radar</div>
+                                    <div className="list-title">Posição no radar</div>
                                     <div className="list-subtle">
                                         Comparativo com as bandeiras mais ativas.
                                     </div>
@@ -396,7 +396,7 @@ export default function MapPage() {
                                 <div>
                                     <div className="list-title">Membro com mais tiles</div>
                                     <div className="list-subtle">
-                                        Destaque interno para comunicacao da equipe.
+                                        Destaque interno para comunicação da equipe.
                                     </div>
                                 </div>
                                 <strong>{topMember?.username ?? 'Sem dado'}</strong>
@@ -411,10 +411,10 @@ export default function MapPage() {
                         </div>
                     ) : (
                         <div className="empty-state">
-                            <strong>Voce ainda nao esta em uma bandeira.</strong>
+                            <strong>Você ainda não está em uma bandeira.</strong>
                             <span>
                                 Entre em uma equipe para desbloquear leitura de
-                                ranking, roster e operacao coletiva.
+                                ranking, roster e operação coletiva.
                             </span>
                             <Link href="/bandeira" className="btn btn-primary btn-sm">
                                 Encontrar bandeira
@@ -426,7 +426,7 @@ export default function MapPage() {
                 <article className="panel">
                     <div className="section-header">
                         <span className="section-kicker">Leitura de crescimento</span>
-                        <h2>Onde a plataforma pode ganhar tracao.</h2>
+                        <h2>Onde a plataforma pode ganhar tração.</h2>
                     </div>
 
                     <div className="list">
@@ -449,7 +449,7 @@ export default function MapPage() {
                 <article className={`${styles.featuredCard} panel panel-dark`}>
                     <div className="section-header">
                         <span className="section-kicker">Bandeiras em destaque</span>
-                        <h2>Quem esta puxando a conversa agora.</h2>
+                        <h2>Quem está puxando a conversa agora.</h2>
                     </div>
 
                     <div className="list">
@@ -471,8 +471,8 @@ export default function MapPage() {
 
                 <article className="panel panel-strong">
                     <div className="section-header">
-                        <span className="section-kicker">Proxima acao</span>
-                        <h2>Use o web para aprofundar relacao com a comunidade.</h2>
+                        <span className="section-kicker">Próxima ação</span>
+                        <h2>Use o web para aprofundar relação com a comunidade.</h2>
                         <p className="section-copy">
                             O produto fica mais forte quando a leitura do
                             corredor alimenta a narrativa da bandeira e gera um

--- a/frontend/src/app/(game)/profile/page.test.tsx
+++ b/frontend/src/app/(game)/profile/page.test.tsx
@@ -84,6 +84,6 @@ describe('ProfilePage', () => {
 
         expect(screen.getByText('78.0 km')).toBeInTheDocument()
         expect(screen.getAllByText('Passada Forte')).toHaveLength(2)
-        expect(screen.getByText(/Como voce esta performando/i)).toBeInTheDocument()
+        expect(screen.getByText(/Como você está performando/i)).toBeInTheDocument()
     })
 })

--- a/frontend/src/app/(game)/profile/page.tsx
+++ b/frontend/src/app/(game)/profile/page.tsx
@@ -36,10 +36,10 @@ export default function ProfilePage() {
                 if (!isMounted) return
 
                 if (runsResult.status === 'fulfilled') setRuns(runsResult.value)
-                else setError('Nao foi possivel carregar todas as sessoes do perfil.')
+                else setError('Não foi possível carregar todas as sessões do perfil.')
 
                 if (dailyStatusResult.status === 'fulfilled') setDailyStatus(dailyStatusResult.value)
-                else setError('Nao foi possivel carregar todas as sessoes do perfil.')
+                else setError('Não foi possível carregar todas as sessões do perfil.')
             } finally {
                 if (isMounted) {
                     setLoadingData(false)
@@ -77,7 +77,7 @@ export default function ProfilePage() {
         return (
             <div className={styles.page}>
                 <div className="empty-state">
-                    <strong>Voce precisa estar logado para ver seu perfil.</strong>
+                    <strong>Você precisa estar logado para ver seu perfil.</strong>
                     <Link href="/login" className="btn btn-primary btn-sm">
                         Fazer login
                     </Link>
@@ -103,7 +103,7 @@ export default function ProfilePage() {
                                 {user.bandeiraName ?? 'Sem bandeira'}
                             </span>
                             <span className="tag">
-                                {user.isPublic ? 'Perfil publico' : 'Perfil privado'}
+                                {user.isPublic ? 'Perfil público' : 'Perfil privado'}
                             </span>
                         </div>
                     </div>
@@ -113,16 +113,16 @@ export default function ProfilePage() {
                     <span className="metric-label">Estado atual</span>
                     <strong className="metric-value">{snapshot.averagePace}</strong>
                     <span className="metric-detail">
-                        Ritmo medio das corridas validadas e {snapshot.activeDays} dias
-                        ativos na ultima semana.
+                        Ritmo médio das corridas validadas e {snapshot.activeDays} dias
+                        ativos na última semana.
                     </span>
                     <div className={styles.summaryRows}>
                         <div>
-                            <span>Acoes hoje</span>
+                            <span>Ações hoje</span>
                             <strong>{dailyStatus?.userActionsRemaining ?? 0}</strong>
                         </div>
                         <div>
-                            <span>Ultima corrida</span>
+                            <span>Última corrida</span>
                             <strong>{formatDateLabel(snapshot.lastRunAt)}</strong>
                         </div>
                     </div>
@@ -133,14 +133,14 @@ export default function ProfilePage() {
 
             <section className="metric-grid">
                 <article className="panel metric-card">
-                    <span className="metric-label">Distancia acumulada</span>
+                    <span className="metric-label">Distância acumulada</span>
                     <strong className="metric-value">{formatDistance(user.totalDistance)}</strong>
                     <span className="metric-detail">Base total consolidada da conta.</span>
                 </article>
                 <article className="panel metric-card">
                     <span className="metric-label">Corridas totais</span>
                     <strong className="metric-value">{user.totalRuns}</strong>
-                    <span className="metric-detail">Volume historico registrado.</span>
+                    <span className="metric-detail">Volume histórico registrado.</span>
                 </article>
                 <article className="panel metric-card">
                     <span className="metric-label">Tiles conquistados</span>
@@ -152,7 +152,7 @@ export default function ProfilePage() {
                     <strong className="metric-value">
                         {formatPercentage(snapshot.validatedRate)}
                     </strong>
-                    <span className="metric-detail">Leitura de consistencia dos seus envios.</span>
+                    <span className="metric-detail">Leitura de consistência dos seus envios.</span>
                 </article>
             </section>
 
@@ -160,28 +160,28 @@ export default function ProfilePage() {
                 <article className="panel">
                     <div className="section-header">
                         <span className="section-kicker">Leitura pessoal</span>
-                        <h2>Como voce esta performando.</h2>
+                        <h2>Como você está performando.</h2>
                     </div>
 
                     <div className="list">
                         <div className="list-item">
                             <div>
                                 <div className="list-title">Semana atual</div>
-                                <div className="list-subtle">Distancia acumulada nos ultimos 7 dias.</div>
+                                <div className="list-subtle">Distância acumulada nos últimos 7 dias.</div>
                             </div>
                             <strong>{formatDistance(snapshot.weeklyDistance)}</strong>
                         </div>
                         <div className="list-item">
                             <div>
-                                <div className="list-title">Maior sessao recente</div>
-                                <div className="list-subtle">Melhor distancia desta amostra.</div>
+                                <div className="list-title">Maior sessão recente</div>
+                                <div className="list-subtle">Melhor distância desta amostra.</div>
                             </div>
                             <strong>{formatDistance(snapshot.longestRun)}</strong>
                         </div>
                         <div className="list-item">
                             <div>
-                                <div className="list-title">Conversao territorial</div>
-                                <div className="list-subtle">Quanto das corridas validadas vira acao util.</div>
+                                <div className="list-title">Conversão territorial</div>
+                                <div className="list-subtle">Quanto das corridas validadas vira ação útil.</div>
                             </div>
                             <strong>{formatPercentage(snapshot.territoryConversion)}</strong>
                         </div>
@@ -190,8 +190,8 @@ export default function ProfilePage() {
 
                 <article className="panel">
                     <div className="section-header">
-                        <span className="section-kicker">Ultimas sessoes</span>
-                        <h2>Historico recente.</h2>
+                        <span className="section-kicker">Últimas sessões</span>
+                        <h2>Histórico recente.</h2>
                     </div>
 
                     {sortedRuns.length > 0 ? (
@@ -210,7 +210,7 @@ export default function ProfilePage() {
                         </div>
                     ) : (
                         <div className="empty-state">
-                            <strong>Sem sessoes recentes.</strong>
+                            <strong>Sem sessões recentes.</strong>
                             <span>Assim que corridas entrarem, o perfil organiza a leitura aqui.</span>
                         </div>
                     )}
@@ -235,7 +235,7 @@ export default function ProfilePage() {
                                     <div className="list-title">Visibilidade</div>
                                     <div className="list-subtle">Como o perfil aparece para a comunidade.</div>
                                 </div>
-                                <strong>{user.isPublic ? 'Publico' : 'Privado'}</strong>
+                                <strong>{user.isPublic ? 'Público' : 'Privado'}</strong>
                             </div>
                         </div>
                         <div className={styles.sideActions}>

--- a/frontend/src/app/(game)/rankings/page.test.tsx
+++ b/frontend/src/app/(game)/rankings/page.test.tsx
@@ -57,7 +57,7 @@ describe('RankingsPage', () => {
         await waitFor(() =>
             expect(
                 screen.getByRole('heading', {
-                    name: /O ranking agora serve para leitura e captacao/i,
+                    name: /O ranking agora serve para leitura e captação/i,
                 })
             ).toBeInTheDocument()
         )

--- a/frontend/src/app/(game)/rankings/page.tsx
+++ b/frontend/src/app/(game)/rankings/page.tsx
@@ -23,7 +23,7 @@ export default function RankingsPage() {
                 setBandeiras(data)
             } catch {
                 if (!isMounted) return
-                setError('Nao foi possivel carregar o radar competitivo agora.')
+                setError('Não foi possível carregar o radar competitivo agora.')
             } finally {
                 if (isMounted) {
                     setLoading(false)
@@ -61,23 +61,23 @@ export default function RankingsPage() {
                 <div className="section-header">
                     <span className="section-kicker">Radar competitivo</span>
                     <h1 className="section-title">
-                        O ranking agora serve para leitura e captacao, nao so
-                        para exibicao.
+                        O ranking agora serve para leitura e captação, não só
+                        para exibição.
                     </h1>
                     <p className="section-copy">
                         Compare peso territorial, densidade de membros e tipos
                         de comunidade mais ativos. Isso ajuda a contar melhor a
-                        historia da plataforma para novos grupos e assessorias.
+                        história da plataforma para novos grupos e assessorias.
                     </p>
                 </div>
 
                 <aside className={`${styles.leaderCard} panel panel-dark`}>
                     <span className="metric-label">Lider atual</span>
-                    <strong className="metric-value">{leader?.name ?? 'Sem lider'}</strong>
+                    <strong className="metric-value">{leader?.name ?? 'Sem líder'}</strong>
                     <span className="metric-detail">
                         {leader
                             ? `${getCategoryLabel(leader.category)} com ${leader.memberCount} membros`
-                            : 'Ainda nao ha bandeiras no ranking.'}
+                            : 'Ainda não há bandeiras no ranking.'}
                     </span>
                     {leader && (
                         <div className={styles.leaderMeta}>
@@ -100,7 +100,7 @@ export default function RankingsPage() {
                 <article className="panel metric-card">
                     <span className="metric-label">Bandeiras ranqueadas</span>
                     <strong className="metric-value">{bandeiras.length}</strong>
-                    <span className="metric-detail">Base atual de comunidades visiveis no radar.</span>
+                    <span className="metric-detail">Base atual de comunidades visíveis no radar.</span>
                 </article>
                 <article className="panel metric-card">
                     <span className="metric-label">Membros somados</span>
@@ -110,10 +110,10 @@ export default function RankingsPage() {
                 <article className="panel metric-card">
                     <span className="metric-label">Tiles somados</span>
                     <strong className="metric-value">{totalTiles}</strong>
-                    <span className="metric-detail">Presenca territorial acumulada das equipes.</span>
+                    <span className="metric-detail">Presença territorial acumulada das equipes.</span>
                 </article>
                 <article className="panel metric-card">
-                    <span className="metric-label">Categorias com tracao</span>
+                    <span className="metric-label">Categorias com tração</span>
                     <strong className="metric-value">{categoryBreakdown.length}</strong>
                     <span className="metric-detail">Categorias ativas para comunicar oferta do produto.</span>
                 </article>
@@ -158,7 +158,7 @@ export default function RankingsPage() {
                     <article className="panel">
                         <div className="section-header">
                             <span className="section-kicker">Leitura por categoria</span>
-                            <h2>Quais formatos estao puxando tracao.</h2>
+                        <h2>Quais formatos estão puxando tração.</h2>
                         </div>
 
                         <div className="list">
@@ -183,7 +183,7 @@ export default function RankingsPage() {
                         </div>
                         <p className="section-copy">
                             Ranking com contexto ajuda a vender o produto para
-                            novas assessorias: nao e so disputa, e densidade de
+                            novas assessorias: não é só disputa, é densidade de
                             comunidade com visibilidade.
                         </p>
                         <Link href="/bandeira" className="btn btn-primary">

--- a/frontend/src/app/(game)/run/page.test.tsx
+++ b/frontend/src/app/(game)/run/page.test.tsx
@@ -66,12 +66,12 @@ describe('RunPage', () => {
         await waitFor(() =>
             expect(
                 screen.getByRole('heading', {
-                    name: /O navegador nao grava corrida/i,
+                    name: /O navegador não grava corrida/i,
                 })
             ).toBeInTheDocument()
         )
 
-        expect(screen.getByText(/Ultimas sessoes lidas pelo sistema/i)).toBeInTheDocument()
+        expect(screen.getByText(/Últimas sessões lidas pelo sistema/i)).toBeInTheDocument()
         expect(screen.queryByText('Upload GPX')).not.toBeInTheDocument()
         expect(screen.getByText('Conquista')).toBeInTheDocument()
     })

--- a/frontend/src/app/(game)/run/page.tsx
+++ b/frontend/src/app/(game)/run/page.tsx
@@ -35,7 +35,7 @@ export default function RunPage() {
                 setRuns(data)
             } catch {
                 if (!isMounted) return
-                setError('Nao foi possivel carregar as sessoes agora.')
+                setError('Não foi possível carregar as sessões agora.')
             } finally {
                 if (isMounted) {
                     setLoading(false)
@@ -68,7 +68,7 @@ export default function RunPage() {
         return (
             <div className={styles.loading}>
                 <div className="spinner"></div>
-                <span>Carregando analise das sessoes...</span>
+                <span>Carregando análise das sessões...</span>
             </div>
         )
     }
@@ -77,23 +77,23 @@ export default function RunPage() {
         <div className={styles.page}>
             <section className={styles.hero}>
                 <div className="section-header">
-                    <span className="section-kicker">Sessoes e consistencia</span>
+                    <span className="section-kicker">Sessões e consistência</span>
                     <h1 className="section-title">
-                        O navegador nao grava corrida. Ele organiza e explica o
-                        que ja aconteceu.
+                        O navegador não grava corrida. Ele organiza e explica o
+                        que já aconteceu.
                     </h1>
                     <p className="section-copy">
-                        Use esta tela para ler o historico recente, comparar
-                        validacao, entender impacto territorial e acompanhar a
+                        Use esta tela para ler o histórico recente, comparar
+                        validação, entender impacto territorial e acompanhar a
                         regularidade do corredor.
                     </p>
                 </div>
 
                 <aside className={`${styles.heroCard} panel panel-strong`}>
-                    <span className="metric-label">Resumo rapido</span>
+                    <span className="metric-label">Resumo rápido</span>
                     <strong className="metric-value">{snapshot.averagePace}</strong>
                     <span className="metric-detail">
-                        Ritmo medio calculado a partir das corridas validadas.
+                        Ritmo médio calculado a partir das corridas validadas.
                     </span>
                     <div className={styles.heroCardList}>
                         <div>
@@ -101,11 +101,11 @@ export default function RunPage() {
                             <strong>{formatDistance(snapshot.weeklyDistance)}</strong>
                         </div>
                         <div>
-                            <span>Validacao</span>
+                            <span>Validação</span>
                             <strong>{formatPercentage(snapshot.validatedRate)}</strong>
                         </div>
                         <div>
-                            <span>Acao territorial</span>
+                            <span>Ação territorial</span>
                             <strong>{territoryRuns.length}</strong>
                         </div>
                     </div>
@@ -118,24 +118,24 @@ export default function RunPage() {
                 <article className="panel metric-card">
                     <span className="metric-label">Corridas lidas</span>
                     <strong className="metric-value">{sortedRuns.length}</strong>
-                    <span className="metric-detail">Amostra mais recente disponivel para analise.</span>
+                    <span className="metric-detail">Amostra mais recente disponível para análise.</span>
                 </article>
                 <article className="panel metric-card">
-                    <span className="metric-label">Maior sessao</span>
+                    <span className="metric-label">Maior sessão</span>
                     <strong className="metric-value">{formatDistance(snapshot.longestRun)}</strong>
-                    <span className="metric-detail">Maior distancia desta janela de consulta.</span>
+                    <span className="metric-detail">Maior distância desta janela de consulta.</span>
                 </article>
                 <article className="panel metric-card">
                     <span className="metric-label">Dias ativos</span>
                     <strong className="metric-value">{snapshot.activeDays}</strong>
-                    <span className="metric-detail">Dias com sessao registrada nos ultimos 7 dias.</span>
+                    <span className="metric-detail">Dias com sessão registrada nos últimos 7 dias.</span>
                 </article>
                 <article className="panel metric-card">
-                    <span className="metric-label">Conversao territorial</span>
+                    <span className="metric-label">Conversão territorial</span>
                     <strong className="metric-value">
                         {formatPercentage(snapshot.territoryConversion)}
                     </strong>
-                    <span className="metric-detail">Quanto das corridas validadas vira acao no mapa.</span>
+                    <span className="metric-detail">Quanto das corridas validadas vira ação no mapa.</span>
                 </article>
             </section>
 
@@ -143,7 +143,7 @@ export default function RunPage() {
                 <article className="panel">
                     <div className="section-header">
                         <span className="section-kicker">Timeline</span>
-                        <h2>Ultimas sessoes lidas pelo sistema.</h2>
+                        <h2>Últimas sessões lidas pelo sistema.</h2>
                     </div>
 
                     {sortedRuns.length > 0 ? (
@@ -183,8 +183,8 @@ export default function RunPage() {
                                             <strong>{formatPace(run.distance, run.duration)}</strong>
                                         </div>
                                         <div>
-                                            <span>Loop valido</span>
-                                            <strong>{run.isLoopValid ? 'Sim' : 'Nao'}</strong>
+                                            <span>Loop válido</span>
+                                            <strong>{run.isLoopValid ? 'Sim' : 'Não'}</strong>
                                         </div>
                                         <div>
                                             <span>Tile alvo</span>
@@ -196,7 +196,7 @@ export default function RunPage() {
                         </div>
                     ) : (
                         <div className="empty-state">
-                            <strong>Nenhuma sessao encontrada.</strong>
+                            <strong>Nenhuma sessão encontrada.</strong>
                             <span>
                                 O app captura seus treinos; a web mostra a
                                 leitura assim que eles entram na conta.
@@ -208,8 +208,8 @@ export default function RunPage() {
                 <aside className={styles.sideStack}>
                     <article className="panel">
                         <div className="section-header">
-                            <span className="section-kicker">Origem das sessoes</span>
-                            <h2>Como esse historico entrou.</h2>
+                            <span className="section-kicker">Origem das sessões</span>
+                            <h2>Como esse histórico entrou.</h2>
                         </div>
 
                         <div className="list">
@@ -218,7 +218,7 @@ export default function RunPage() {
                                     <div>
                                         <div className="list-title">{origin}</div>
                                         <div className="list-subtle">
-                                            Sesssoes recebidas por esta origem.
+                                            Sessões recebidas por esta origem.
                                         </div>
                                     </div>
                                     <strong>{total}</strong>
@@ -230,12 +230,12 @@ export default function RunPage() {
                     <article className="panel panel-strong">
                         <div className="section-header">
                             <span className="section-kicker">Uso da web</span>
-                            <h2>Camada analitica, nao gravador.</h2>
+                            <h2>Camada analítica, não gravador.</h2>
                         </div>
                         <p className="section-copy">
                             Esse reposicionamento tira atrito do navegador e
                             deixa claro o papel da interface: ler, comparar e
-                            orientar a proxima decisao.
+                            orientar a próxima decisão.
                         </p>
                         <div className={styles.sideActions}>
                             <Link href="/map" className="btn btn-secondary">

--- a/frontend/src/app/home2/page.tsx
+++ b/frontend/src/app/home2/page.tsx
@@ -7,12 +7,12 @@ const focusAreas = [
     {
         title: 'Painel do corredor',
         description:
-            'Distancia, consistencia, ritmo e impacto territorial ficam organizados numa visao pronta para decisao.',
+            'Distância, consistência, ritmo e impacto territorial ficam organizados numa visão pronta para decisão.',
     },
     {
         title: 'Painel da bandeira',
         description:
-            'Veja membros ativos, presenca da equipe e oportunidades de crescimento por categoria e regiao.',
+            'Veja membros ativos, presença da equipe e oportunidades de crescimento por categoria e região.',
     },
     {
         title: 'Painel de aquisicao',
@@ -24,30 +24,30 @@ const focusAreas = [
 const audiences = [
     {
         kicker: 'Para corredores',
-        title: 'Entenda o seu momento sem abrir varias telas.',
+        title: 'Entenda o seu momento sem abrir várias telas.',
         description:
-            'A web vira um cockpit: historico recente, tendencia semanal, bandeira atual e proximos movimentos.',
-        metrics: ['Consistencia semanal', 'Ritmo medio', 'Ultimas sessoes'],
+            'A web vira um cockpit: histórico recente, tendência semanal, bandeira atual e próximos movimentos.',
+        metrics: ['Consistência semanal', 'Ritmo médio', 'Últimas sessões'],
     },
     {
         kicker: 'Para grupos',
-        title: 'Mostre presenca e mantenha a crew engajada.',
+        title: 'Mostre presença e mantenha a crew engajada.',
         description:
-            'As bandeiras deixam de ser apenas um nome. Elas passam a ter narrativa, ranking, membros e crescimento visivel.',
-        metrics: ['Radar competitivo', 'Times em destaque', 'Distribuicao por categoria'],
+            'As bandeiras deixam de ser apenas um nome. Elas passam a ter narrativa, ranking, membros e crescimento visível.',
+        metrics: ['Radar competitivo', 'Times em destaque', 'Distribuição por categoria'],
     },
     {
         kicker: 'Para assessorias',
         title: 'Transforme alunos em comunidade acionavel.',
         description:
-            'A assessoria consegue apresentar performance coletiva, presenca territorial e valor de marca em uma camada unica.',
+            'A assessoria consegue apresentar performance coletiva, presença territorial e valor de marca em uma camada única.',
         metrics: ['Leads de comunidade', 'Narrativa de marca', 'Escala de membros'],
     },
 ]
 
 const productSteps = [
     'Sincronize os treinos no app e acompanhe tudo no painel web.',
-    'Leia o momento do corredor, da bandeira e do mapa com blocos analiticos.',
+    'Leia o momento do corredor, da bandeira e do mapa com blocos analíticos.',
     'Use o radar para atrair novos membros, crews e assessorias para a plataforma.',
 ]
 
@@ -79,8 +79,8 @@ export default function Home2() {
                         </h1>
                         <p className={styles.heroText}>
                             LigaRun passa a ser um painel de leitura,
-                            consistencia e crescimento. O app captura a corrida.
-                            A web organiza performance, comunidade e expansao.
+                            consistência e crescimento. O app captura a corrida.
+                            A web organiza performance, comunidade e expansão.
                         </p>
 
                         <div className={styles.heroActions}>
@@ -94,12 +94,12 @@ export default function Home2() {
 
                         <div className={styles.heroMetrics}>
                             <div className="panel metric-card">
-                                <span className="metric-label">Visao do corredor</span>
+                                <span className="metric-label">Visão do corredor</span>
                                 <strong className="metric-value">360</strong>
-                                <span className="metric-detail">Historico, ritmo e consistencia em uma leitura unica.</span>
+                                <span className="metric-detail">Histórico, ritmo e consistência em uma leitura única.</span>
                             </div>
                             <div className="panel metric-card">
-                                <span className="metric-label">Visao da bandeira</span>
+                                <span className="metric-label">Visão da bandeira</span>
                                 <strong className="metric-value">1 painel</strong>
                                 <span className="metric-detail">Membros, ranking, tiles e categorias lado a lado.</span>
                             </div>
@@ -113,27 +113,27 @@ export default function Home2() {
                                     <span className={styles.previewKicker}>Painel Central</span>
                                     <h2>Corredor + bandeira + crescimento</h2>
                                 </div>
-                                <span className="tag tag-accent">Analitico</span>
+                                <span className="tag tag-accent">Analítico</span>
                             </div>
 
                             <div className={styles.previewGrid}>
                                 <div className={styles.previewCard}>
                                     <span className="metric-label">Semana</span>
                                     <strong className="metric-value">28,4 km</strong>
-                                    <span className="metric-detail">4 dias ativos e ritmo estavel.</span>
+                                    <span className="metric-detail">4 dias ativos e ritmo estável.</span>
                                 </div>
                                 <div className={styles.previewCard}>
                                     <span className="metric-label">Bandeira</span>
                                     <strong className="metric-value">#2 no radar</strong>
-                                    <span className="metric-detail">42 membros, 118 tiles e alta recorrencia.</span>
+                                    <span className="metric-detail">42 membros, 118 tiles e alta recorrência.</span>
                                 </div>
                                 <div className={styles.previewCardWide}>
                                     <span className="metric-label">Oportunidade</span>
                                     <strong className={styles.previewOpportunity}>
-                                        Assessoria com boa escala, mas pouca presenca territorial.
+                                        Assessoria com boa escala, mas pouca presença territorial.
                                     </strong>
                                     <span className="metric-detail">
-                                        O web passa a gerar argumento para novas parcerias e novos usuarios.
+                                        O web passa a gerar argumento para novas parcerias e novos usuários.
                                     </span>
                                 </div>
                             </div>
@@ -148,12 +148,12 @@ export default function Home2() {
                         <span className="section-kicker">Reposicionamento</span>
                         <h2 className="section-title">
                             O produto deixa de pedir corrida no navegador e
-                            passa a entregar leitura de negocio e performance.
+                            passa a entregar leitura de negócio e performance.
                         </h2>
                         <p className="section-copy">
-                            O ganho aqui nao e so visual. E de clareza de uso:
-                            corredor entende sua evolucao, bandeira entende sua
-                            operacao, e a plataforma comunica melhor valor para
+                            O ganho aqui não é só visual. É de clareza de uso:
+                            corredor entende sua evolução, bandeira entende sua
+                            operação, e a plataforma comunica melhor valor para
                             grupos e assessorias.
                         </p>
                     </div>
@@ -172,7 +172,7 @@ export default function Home2() {
             <section className={styles.audienceSection}>
                 <div className="page-shell">
                     <div className={`${styles.audienceIntro} section-header`}>
-                        <span className="section-kicker">Publicos</span>
+                        <span className="section-kicker">Públicos</span>
                         <h2 className="section-title">Uma home que conversa com quem decide e com quem corre.</h2>
                     </div>
 
@@ -217,15 +217,15 @@ export default function Home2() {
                 <div className="page-shell">
                     <div className={`${styles.finalCard} panel panel-dark`}>
                         <div className="section-header">
-                            <span className="section-kicker">Proxima versao da marca</span>
+                            <span className="section-kicker">Próxima versão da marca</span>
                             <h2 className="section-title">
-                                Mais util para o corredor. Mais atraente para crews e assessorias.
+                                Mais útil para o corredor. Mais atraente para crews e assessorias.
                             </h2>
                             <p className="section-copy">
-                                Essa refatoracao web posiciona a plataforma como
+                                Essa refatoração web posiciona a plataforma como
                                 um centro de controle e relacionamento. E isso
-                                aumenta recorrencia, clareza e potencial de
-                                captacao.
+                                aumenta recorrência, clareza e potencial de
+                                captação.
                             </p>
                         </div>
 

--- a/frontend/src/app/layout.tsx
+++ b/frontend/src/app/layout.tsx
@@ -30,7 +30,7 @@ export const metadata: Metadata = {
     metadataBase,
     title: 'LigaRun | Painel do Corredor e da Bandeira',
     description:
-        'Painel analitico para corredores, grupos e assessorias acompanharem performance, territorio e crescimento da comunidade.',
+        'Painel analítico para corredores, grupos e assessorias acompanharem performance, território e crescimento da comunidade.',
     keywords: [
         'corrida',
         'painel do corredor',
@@ -43,7 +43,7 @@ export const metadata: Metadata = {
     openGraph: {
         title: 'LigaRun | Painel do Corredor e da Bandeira',
         description:
-            'Controle corridas, territorio, consistencia e crescimento da sua bandeira em um painel unico.',
+            'Controle corridas, território, consistência e crescimento da sua bandeira em um painel único.',
         type: 'website',
     },
 }

--- a/frontend/src/components/social-auth/SocialAuthButtons.tsx
+++ b/frontend/src/components/social-auth/SocialAuthButtons.tsx
@@ -80,7 +80,7 @@ export default function SocialAuthButtons({
             const idToken = authorization?.id_token
             const code = authorization?.code
 
-            if (!idToken) throw new Error('Apple nao retornou um token.')
+            if (!idToken) throw new Error('Apple não retornou um token.')
 
             await onSocialSignIn({
                 provider: 'apple',
@@ -96,7 +96,7 @@ export default function SocialAuthButtons({
 
     return (
         <div className={styles.wrapper}>
-            <p className={styles.lead}>Use Google ou Apple para entrar mais rapido.</p>
+            <p className={styles.lead}>Use Google ou Apple para entrar mais rápido.</p>
             <div className={styles.buttons}>
                 <button
                     type="button"
@@ -156,7 +156,7 @@ async function ensureAppleLibrary() {
 function loadScript(src: string) {
     return new Promise<void>((resolve, reject) => {
         if (typeof document === 'undefined') {
-            reject(new Error('Document nao esta disponivel.'))
+            reject(new Error('Document não está disponível.'))
             return
         }
 
@@ -180,4 +180,3 @@ declare global {
         AppleID?: any
     }
 }
-

--- a/frontend/src/components/social-auth/SocialLinkRequiredPanel.tsx
+++ b/frontend/src/components/social-auth/SocialLinkRequiredPanel.tsx
@@ -45,7 +45,7 @@ export default function SocialLinkRequiredPanel({
             role="alert"
             aria-live="assertive"
         >
-            <div className={styles.linkBadge}>Acao necessaria</div>
+            <div className={styles.linkBadge}>Ação necessária</div>
             <div className={styles.linkHeader}>
                 <h3>Confirme sua conta para continuar com {providerLabel}</h3>
                 <p>

--- a/frontend/src/lib/dashboard.test.ts
+++ b/frontend/src/lib/dashboard.test.ts
@@ -97,7 +97,7 @@ describe('dashboard helpers', () => {
         expect(formatDistance(14200)).toBe('14.2 km')
         expect(formatPace(10000, 3000)).toBe('5:00/km')
         expect(getRunStatusLabel(baseRuns[0])).toBe('Validada')
-        expect(getRunOutcomeLabel(baseRuns[2])).toBe('Fora de territorio')
+        expect(getRunOutcomeLabel(baseRuns[2])).toBe('Fora de território')
     })
 
 

--- a/frontend/src/lib/dashboard.ts
+++ b/frontend/src/lib/dashboard.ts
@@ -10,7 +10,7 @@ const BANDEIRA_CATEGORY_LABELS: Record<Bandeira['category'], string> = {
 }
 
 const ROLE_LABELS: Record<User['role'], string> = {
-    ADMIN: 'Capitao',
+    ADMIN: 'Capitão',
     COACH: 'Coach',
     MEMBER: 'Membro',
 }
@@ -227,6 +227,6 @@ export function getRunOutcomeLabel(run: Run): string {
         case 'DEFENSE':
             return 'Defesa'
         default:
-            return run.isValidForTerritory ? 'Sem acao' : 'Fora de territorio'
+            return run.isValidForTerritory ? 'Sem ação' : 'Fora de território'
     }
 }


### PR DESCRIPTION
## Resumo
- corrige acentuação, pontuação e grafia em textos visíveis do frontend
- padroniza rótulos e mensagens auxiliares para PT-BR consistente
- atualiza os testes impactados pelas mudanças de cópia

## Validação
- npm test -- --runInBand
- npm run build